### PR TITLE
Fix broken tests

### DIFF
--- a/__tests__/ain.test.ts
+++ b/__tests__/ain.test.ts
@@ -172,6 +172,7 @@ describe('ain-js', function() {
     it('signTransaction', function() {
       const tx: TransactionBody = {
         nonce: 17,
+        gas_price: 500,
         timestamp: Date.now(),
         operation: {
           type: "SET_VALUE",
@@ -187,6 +188,7 @@ describe('ain-js', function() {
     it('recover', function() {
       const tx: TransactionBody = {
         nonce: 17,
+        gas_price: 500,
         timestamp: Date.now(),
         operation: {
           type: "SET_VALUE",
@@ -217,6 +219,7 @@ describe('ain-js', function() {
       ain.setProvider(test_node_2, 0);
       let tx: TransactionBody = {
         nonce: 17,
+        gas_price: 500,
         timestamp: Date.now(),
         operation: {
           type: "SET_VALUE",
@@ -375,6 +378,7 @@ describe('ain-js', function() {
     it('sendSignedTransaction', function(done) {
       const tx: TransactionBody = {
         nonce: -1,
+        gas_price: 500,
         timestamp: Date.now(),
         operation: {
           type: "SET_OWNER",

--- a/__tests__/ain.test.ts
+++ b/__tests__/ain.test.ts
@@ -714,7 +714,7 @@ describe('ain-js', function() {
     });
 
     it('deleteValue', function(done) {
-      ain.db.ref(allowed_path).deleteValue()
+      ain.db.ref(`${allowed_path}/can/write`).deleteValue()
       .then(res => {
         expect(res.result.code).toBe(0);
         done();

--- a/__tests__/ain.test.ts
+++ b/__tests__/ain.test.ts
@@ -15,7 +15,7 @@ const {
   test_node_2
 } = require('./test_data');
 
-jest.setTimeout(60000);
+jest.setTimeout(180000);
 
 // TODO (lia): Create more test cases
 describe('ain-js', function() {
@@ -281,7 +281,7 @@ describe('ain-js', function() {
           return true;
         }
         await new Promise((resolve) => {
-          setTimeout(resolve, 3000);
+          setTimeout(resolve, 5000);
         });
         iterCount++;
       }

--- a/__tests__/ain.test.ts
+++ b/__tests__/ain.test.ts
@@ -498,7 +498,7 @@ describe('ain-js', function() {
 
       ain.sendTransactionBatch([ tx1, tx2, tx3, tx4, tx5, tx6 ])
       .then(res => {
-        expect(res[0].result.code).toBe(103);
+        expect(res[0].result.code).toBe(12103);
         expect(res[0].tx_hash).toEqual(expect.stringMatching(TX_PATTERN));
         expect(res[1].result.result_list[0].code).toBe(0);
         expect(res[1].tx_hash).toEqual(expect.stringMatching(TX_PATTERN));
@@ -506,9 +506,9 @@ describe('ain-js', function() {
         expect(res[2].tx_hash).toEqual(expect.stringMatching(TX_PATTERN));
         expect(res[3].result.code).toBe(0);
         expect(res[3].tx_hash).toEqual(expect.stringMatching(TX_PATTERN));
-        expect(res[4].result.code).toBe(103);
+        expect(res[4].result.code).toBe(12103);
         expect(res[4].tx_hash).toEqual(expect.stringMatching(TX_PATTERN));
-        expect(res[5].result.code).toBe(503);
+        expect(res[5].result.code).toBe(12302);
         expect(res[5].tx_hash).toEqual(expect.stringMatching(TX_PATTERN));
         done();
       })
@@ -574,7 +574,7 @@ describe('ain-js', function() {
         }
       })
       .then(res => {
-        expect(res.result.code).toBe(603);
+        expect(res.result.code).toBe(12501);
         done();
       })
       .catch((error) => {
@@ -728,7 +728,7 @@ describe('ain-js', function() {
     it('evalRule: true', function(done) {
       ain.db.ref(allowed_path).evalRule({ ref: '/can/write', value: 'hi' })
       .then(res => {
-        expect(res).toBe(true);
+        expect(res).toStrictEqual({"code": 0, "matched": {"state": {"closestRule": {"config": null, "path": []}, "matchedRulePath": ["apps", "bfan", "users", "0x09A0d53FDf1c36A131938eb379b98910e55EEfe1", "can", "write"], "matchedValuePath": ["apps", "bfan", "users", "0x09A0d53FDf1c36A131938eb379b98910e55EEfe1", "can", "write"], "pathVars": {}}, "write": {"closestRule": {"config": {"write": "true"}, "path": ["apps", "bfan", "users", "0x09A0d53FDf1c36A131938eb379b98910e55EEfe1", "can", "write"]}, "matchedRulePath": ["apps", "bfan", "users", "0x09A0d53FDf1c36A131938eb379b98910e55EEfe1", "can", "write"], "matchedValuePath": ["apps", "bfan", "users", "0x09A0d53FDf1c36A131938eb379b98910e55EEfe1", "can", "write"], "pathVars": {}, "subtreeRules": []}}});
         done();
       })
       .catch(error => {
@@ -740,7 +740,7 @@ describe('ain-js', function() {
     it('evalRule: false', function(done) {
       ain.db.ref(allowed_path).evalRule({ ref: '/cannot/write', value: 'hi' })
       .then(res => {
-        expect(res).toBe(false);
+        expect(res.code).toBe(12103);
         done();
       })
       .catch(error => {

--- a/__tests__/event_manager.test.ts
+++ b/__tests__/event_manager.test.ts
@@ -3,7 +3,7 @@ import Ain from '../src/ain';
 const { test_event_handler_node } = require('./test_data');
 const delayMs = (time) => new Promise(resolve => setTimeout(resolve, time));
 
-jest.setTimeout(60000);
+jest.setTimeout(180000);
 
 describe('Event Handler', function() {
   let ain = new Ain(test_event_handler_node);
@@ -21,7 +21,7 @@ describe('Event Handler', function() {
     ain.em.subscribe('BLOCK_FINALIZED', {}, (data) => {
       callback(data);
     });
-    await delayMs(10000);
+    await delayMs(60000);
     expect(callback).toBeCalled();
   });
 });

--- a/__tests__/he.test.ts
+++ b/__tests__/he.test.ts
@@ -2,7 +2,7 @@ import Ain from '../src/ain';
 import { HomomorphicEncryptionParams } from '../src/types';
 const { test_node_1 } = require('./test_data');
 
-jest.setTimeout(60000);
+jest.setTimeout(180000);
 
 describe('Homomorphic Encryption', function() {
   let ain = new Ain(test_node_1);

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "prepublishOnly": "npm run build",
     "snapshot": "jest --updateSnapshot",
     "test": "jest",
+    "test_ain": "jest ain.test.ts",
     "test_he": "jest he.test.ts",
     "test_em": "jest event_manager.test.ts"
   },

--- a/src/ain-db/ref.ts
+++ b/src/ain-db/ref.ts
@@ -252,7 +252,7 @@ export default class Reference {
    * false if not.
    * @param params
    */
-  evalRule(params: EvalRuleInput): Promise<boolean> {
+  evalRule(params: EvalRuleInput): Promise<any> {
     const address = this._ain.wallet.getImpliedAddress(params.address);
     const request = {
       address,


### PR DESCRIPTION
Fixed broken ain test cases by
  - Increasing timouts (blockchain epoch_ms has been increased)
  - Adding gas_price to transactions
  - Fixing a set value path (can no longer write with subtree rules)
  - Updating tx result codes

That said, the event manager test is still broken (Related: #59)