### PR TITLE
Add get*RawResult() methods to support merged v1 and v2 blockchain get APIs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 node_modules
-__snapshots__
 lib
 .DS_Store
 test_data.ts

--- a/__tests__/__snapshots__/ain.test.ts.snap
+++ b/__tests__/__snapshots__/ain.test.ts.snap
@@ -39,37 +39,6 @@ Object {
 }
 `;
 
-exports[`ain-js Database get 1`] = `
-Array [
-  Object {
-    ".rule": Object {
-      "write": "true",
-    },
-    "can": Object {
-      "write": Object {
-        ".rule": Object {
-          "write": "true",
-        },
-      },
-    },
-    "cannot": Object {
-      "write": Object {
-        ".rule": Object {
-          "write": "false",
-        },
-      },
-    },
-  },
-  Object {
-    "can": Object {
-      "write": -5,
-    },
-    "username": "test_user",
-  },
-  null,
-]
-`;
-
 exports[`ain-js Database get with options 1`] = `null`;
 
 exports[`ain-js Database get with options 2`] = `
@@ -126,70 +95,6 @@ Object {
     "#tree_height:write": 0,
     "#tree_size": 2,
     "#tree_size:write": 1,
-    "write": -5,
-  },
-  "username": "test_user",
-}
-`;
-
-exports[`ain-js Database getFunction 1`] = `
-Object {
-  ".function": Object {
-    "0xFUNCTION_HASH": Object {
-      "function_id": "0xFUNCTION_HASH",
-      "function_type": "REST",
-      "function_url": "https://events.ainetwork.ai/trigger",
-    },
-  },
-}
-`;
-
-exports[`ain-js Database getOwner 1`] = `
-Object {
-  ".owner": Object {
-    "owners": Object {
-      "*": Object {
-        "branch_owner": true,
-        "write_function": true,
-        "write_owner": true,
-        "write_rule": true,
-      },
-      "0x09A0d53FDf1c36A131938eb379b98910e55EEfe1": Object {
-        "branch_owner": true,
-        "write_function": true,
-        "write_owner": true,
-        "write_rule": true,
-      },
-    },
-  },
-}
-`;
-
-exports[`ain-js Database getRule 1`] = `
-Object {
-  ".rule": Object {
-    "write": "true",
-  },
-  "can": Object {
-    "write": Object {
-      ".rule": Object {
-        "write": "true",
-      },
-    },
-  },
-  "cannot": Object {
-    "write": Object {
-      ".rule": Object {
-        "write": "false",
-      },
-    },
-  },
-}
-`;
-
-exports[`ain-js Database getValue 1`] = `
-Object {
-  "can": Object {
     "write": -5,
   },
   "username": "test_user",

--- a/__tests__/__snapshots__/ain.test.ts.snap
+++ b/__tests__/__snapshots__/ain.test.ts.snap
@@ -1,0 +1,291 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ain-js Database evalOwner 1`] = `
+Object {
+  "code": 0,
+  "matched": Object {
+    "closestOwner": Object {
+      "config": Object {
+        "owners": Object {
+          "*": Object {
+            "branch_owner": true,
+            "write_function": true,
+            "write_owner": true,
+            "write_rule": true,
+          },
+          "0x09A0d53FDf1c36A131938eb379b98910e55EEfe1": Object {
+            "branch_owner": true,
+            "write_function": true,
+            "write_owner": true,
+            "write_rule": true,
+          },
+        },
+      },
+      "path": Array [
+        "apps",
+        "bfan",
+        "users",
+        "0x09A0d53FDf1c36A131938eb379b98910e55EEfe1",
+      ],
+    },
+    "matchedOwnerPath": Array [
+      "apps",
+      "bfan",
+      "users",
+      "0x09A0d53FDf1c36A131938eb379b98910e55EEfe1",
+    ],
+    "subtreeOwners": Array [],
+  },
+}
+`;
+
+exports[`ain-js Database get 1`] = `
+Array [
+  Object {
+    ".rule": Object {
+      "write": "true",
+    },
+    "can": Object {
+      "write": Object {
+        ".rule": Object {
+          "write": "true",
+        },
+      },
+    },
+    "cannot": Object {
+      "write": Object {
+        ".rule": Object {
+          "write": "false",
+        },
+      },
+    },
+  },
+  Object {
+    "can": Object {
+      "write": -5,
+    },
+    "username": "test_user",
+  },
+  null,
+]
+`;
+
+exports[`ain-js Database get with options 1`] = `null`;
+
+exports[`ain-js Database get with options 2`] = `
+Object {
+  "can": Object {
+    "write": -5,
+  },
+  "username": "test_user",
+}
+`;
+
+exports[`ain-js Database get with options 3`] = `
+Object {
+  "can": Object {
+    "#state_ph": "0xaf1e44f55da6d7e1aa784dd38372c2c2939570254c6b3f36f80b4878590a9efa",
+  },
+  "username": "test_user",
+}
+`;
+
+exports[`ain-js Database get with options 4`] = `
+Object {
+  "#state_ph": "0x3c067fd41205e87fcead2107a0f346881ea7d95249cdbe34d3d72e28e7c9ecd5",
+  "#state_ph:username": "0xe9acb84e18d9ec64c66358f53c4fec3945eb065a3e98de907d8d80dc1361c82f",
+  "can": Object {
+    "#state_ph": "0xaf1e44f55da6d7e1aa784dd38372c2c2939570254c6b3f36f80b4878590a9efa",
+    "#state_ph:write": "0x60ae6f7084539f2137ca3b45aa2e0e3b6d786a17c8de32110a884e285ea6a00c",
+    "write": -5,
+  },
+  "username": "test_user",
+}
+`;
+
+exports[`ain-js Database get with options 5`] = `
+Object {
+  "#num_children": 2,
+  "#num_children:username": 0,
+  "#num_parents": 1,
+  "#num_parents:username": 2,
+  "#tree_bytes": 698,
+  "#tree_bytes:username": 178,
+  "#tree_height": 2,
+  "#tree_height:username": 0,
+  "#tree_size": 4,
+  "#tree_size:username": 1,
+  "can": Object {
+    "#num_children": 1,
+    "#num_children:write": 0,
+    "#num_parents": 1,
+    "#num_parents:write": 1,
+    "#tree_bytes": 338,
+    "#tree_bytes:write": 168,
+    "#tree_height": 1,
+    "#tree_height:write": 0,
+    "#tree_size": 2,
+    "#tree_size:write": 1,
+    "write": -5,
+  },
+  "username": "test_user",
+}
+`;
+
+exports[`ain-js Database getFunction 1`] = `
+Object {
+  ".function": Object {
+    "0xFUNCTION_HASH": Object {
+      "function_id": "0xFUNCTION_HASH",
+      "function_type": "REST",
+      "function_url": "https://events.ainetwork.ai/trigger",
+    },
+  },
+}
+`;
+
+exports[`ain-js Database getOwner 1`] = `
+Object {
+  ".owner": Object {
+    "owners": Object {
+      "*": Object {
+        "branch_owner": true,
+        "write_function": true,
+        "write_owner": true,
+        "write_rule": true,
+      },
+      "0x09A0d53FDf1c36A131938eb379b98910e55EEfe1": Object {
+        "branch_owner": true,
+        "write_function": true,
+        "write_owner": true,
+        "write_rule": true,
+      },
+    },
+  },
+}
+`;
+
+exports[`ain-js Database getRule 1`] = `
+Object {
+  ".rule": Object {
+    "write": "true",
+  },
+  "can": Object {
+    "write": Object {
+      ".rule": Object {
+        "write": "true",
+      },
+    },
+  },
+  "cannot": Object {
+    "write": Object {
+      ".rule": Object {
+        "write": "false",
+      },
+    },
+  },
+}
+`;
+
+exports[`ain-js Database getValue 1`] = `
+Object {
+  "can": Object {
+    "write": -5,
+  },
+  "username": "test_user",
+}
+`;
+
+exports[`ain-js Database matchFunction 1`] = `
+Object {
+  "matched_config": Object {
+    "config": Object {
+      "0xFUNCTION_HASH": Object {
+        "function_id": "0xFUNCTION_HASH",
+        "function_type": "REST",
+        "function_url": "https://events.ainetwork.ai/trigger",
+      },
+    },
+    "path": "/apps/bfan/users/0x09A0d53FDf1c36A131938eb379b98910e55EEfe1",
+  },
+  "matched_path": Object {
+    "path_vars": Object {},
+    "ref_path": "/apps/bfan/users/0x09A0d53FDf1c36A131938eb379b98910e55EEfe1",
+    "target_path": "/apps/bfan/users/0x09A0d53FDf1c36A131938eb379b98910e55EEfe1",
+  },
+  "subtree_configs": Array [],
+}
+`;
+
+exports[`ain-js Database matchOwner 1`] = `
+Object {
+  "matched_config": Object {
+    "config": Object {
+      "owners": Object {
+        "*": Object {
+          "branch_owner": true,
+          "write_function": true,
+          "write_owner": true,
+          "write_rule": true,
+        },
+        "0x09A0d53FDf1c36A131938eb379b98910e55EEfe1": Object {
+          "branch_owner": true,
+          "write_function": true,
+          "write_owner": true,
+          "write_rule": true,
+        },
+      },
+    },
+    "path": "/apps/bfan/users/0x09A0d53FDf1c36A131938eb379b98910e55EEfe1",
+  },
+  "matched_path": Object {
+    "target_path": "/apps/bfan/users/0x09A0d53FDf1c36A131938eb379b98910e55EEfe1",
+  },
+  "subtree_configs": Array [],
+}
+`;
+
+exports[`ain-js Database matchRule 1`] = `
+Object {
+  "state": Object {
+    "matched_config": Object {
+      "config": null,
+      "path": "/",
+    },
+    "matched_path": Object {
+      "path_vars": Object {},
+      "ref_path": "/apps/bfan/users/0x09A0d53FDf1c36A131938eb379b98910e55EEfe1",
+      "target_path": "/apps/bfan/users/0x09A0d53FDf1c36A131938eb379b98910e55EEfe1",
+    },
+  },
+  "write": Object {
+    "matched_config": Object {
+      "config": Object {
+        "write": "true",
+      },
+      "path": "/apps/bfan/users/0x09A0d53FDf1c36A131938eb379b98910e55EEfe1",
+    },
+    "matched_path": Object {
+      "path_vars": Object {},
+      "ref_path": "/apps/bfan/users/0x09A0d53FDf1c36A131938eb379b98910e55EEfe1",
+      "target_path": "/apps/bfan/users/0x09A0d53FDf1c36A131938eb379b98910e55EEfe1",
+    },
+    "subtree_configs": Array [
+      Object {
+        "config": Object {
+          "write": "true",
+        },
+        "path": "/can/write",
+      },
+      Object {
+        "config": Object {
+          "write": "false",
+        },
+        "path": "/cannot/write",
+      },
+    ],
+  },
+}
+`;
+
+exports[`ain-js Network should set provider 1`] = `true`;

--- a/__tests__/ain.test.ts
+++ b/__tests__/ain.test.ts
@@ -717,38 +717,217 @@ describe('ain-js', function() {
       });
     });
 
-    it('getValue', async function() {
-      expect(await ain.db.ref(allowed_path).getValue()).toMatchSnapshot();
+    it('getValue / getValueV2', async function() {
+      expect(await ain.db.ref(allowed_path).getValue()).toMatchObject({
+        "can": {
+          "write": -5,
+        },
+        "username": "test_user",
+      });
+      expect(await ain.db.ref(allowed_path).getValueV2()).toMatchObject({
+        "result": {
+          "can": {
+            "write": -5,
+          },
+          "username": "test_user",
+        },
+      });
     });
 
-    it('getRule', async function() {
-      expect(await ain.db.ref(allowed_path).getRule()).toMatchSnapshot();
+    it('getRule / getRuleV2', async function() {
+      expect(await ain.db.ref(allowed_path).getRule()).toMatchObject({
+        ".rule": {
+          "write": "true",
+        },
+        "can": {
+          "write": {
+            ".rule": {
+              "write": "true",
+            },
+          },
+        },
+        "cannot": {
+          "write": {
+            ".rule": {
+              "write": "false",
+            },
+          },
+        },
+      });
+      expect(await ain.db.ref(allowed_path).getRuleV2()).toMatchObject({
+        "result": {
+          ".rule": {
+            "write": "true",
+          },
+          "can": {
+            "write": {
+              ".rule": {
+                "write": "true",
+              },
+            },
+          },
+          "cannot": {
+            "write": {
+              ".rule": {
+                "write": "false",
+              },
+            },
+          },
+        },
+      });
     });
 
-    it('getOwner', async function() {
-      expect(await ain.db.ref(allowed_path).getOwner()).toMatchSnapshot();
+    it('getOwner / getOwnerV2', async function() {
+      expect(await ain.db.ref(allowed_path).getOwner()).toMatchObject({
+        ".owner": {
+          "owners": {
+            "*": {
+              "branch_owner": true,
+              "write_function": true,
+              "write_owner": true,
+              "write_rule": true,
+            },
+            "0x09A0d53FDf1c36A131938eb379b98910e55EEfe1": {
+              "branch_owner": true,
+              "write_function": true,
+              "write_owner": true,
+              "write_rule": true,
+            },
+          },
+        },
+      });
+      expect(await ain.db.ref(allowed_path).getOwnerV2()).toMatchObject({
+        "result": {
+          ".owner": {
+            "owners": {
+              "*": {
+                "branch_owner": true,
+                "write_function": true,
+                "write_owner": true,
+                "write_rule": true,
+              },
+              "0x09A0d53FDf1c36A131938eb379b98910e55EEfe1": {
+                "branch_owner": true,
+                "write_function": true,
+                "write_owner": true,
+                "write_rule": true,
+              },
+            },
+          },
+        },
+      });
     });
 
-    it('getFunction', async function() {
-      expect(await ain.db.ref(allowed_path).getFunction()).toMatchSnapshot();
+    it('getFunction / getFunctionV2', async function() {
+      expect(await ain.db.ref(allowed_path).getFunction()).toMatchObject({
+        ".function": {
+          "0xFUNCTION_HASH": {
+            "function_id": "0xFUNCTION_HASH",
+            "function_type": "REST",
+            "function_url": "https://events.ainetwork.ai/trigger",
+          },
+        },
+      });
+      expect(await ain.db.ref(allowed_path).getFunctionV2()).toMatchObject({
+        "result": {
+          ".function": {
+            "0xFUNCTION_HASH": {
+              "function_id": "0xFUNCTION_HASH",
+              "function_type": "REST",
+              "function_url": "https://events.ainetwork.ai/trigger",
+            },
+          },
+        },
+      });
     });
 
-    it('get', async function() {
+    it('get / getV2', async function() {
       expect(await ain.db.ref(allowed_path).get(
-          [
-            {
-              type: 'GET_RULE',
-              ref: ''
-            },
-            {
-              type: 'GET_VALUE',
-            },
-            {
-              type: 'GET_VALUE',
-              ref: 'deeper/path/'
+        [
+          {
+            type: 'GET_RULE',
+            ref: ''
+          },
+          {
+            type: 'GET_VALUE',
+          },
+          {
+            type: 'GET_VALUE',
+            ref: 'deeper/path/'
+          }
+        ]
+      )).toMatchObject([
+        {
+          ".rule": {
+            "write": "true"
+          },
+          "can": {
+            "write": {
+              ".rule": {
+                "write": "true"
+              }
             }
-          ]
-        )).toMatchSnapshot();
+          },
+          "cannot": {
+            "write": {
+              ".rule": {
+                "write": "false"
+              }
+            }
+          }
+        },
+        {
+          "can": {
+            "write": -5
+          },
+          "username": "test_user"
+        },
+        null
+      ]);
+      expect(await ain.db.ref(allowed_path).getV2(
+        [
+          {
+            type: 'GET_RULE',
+            ref: ''
+          },
+          {
+            type: 'GET_VALUE',
+          },
+          {
+            type: 'GET_VALUE',
+            ref: 'deeper/path/'
+          }
+        ]
+      )).toMatchObject({
+        "result": [
+          {
+            ".rule": {
+              "write": "true"
+            },
+            "can": {
+              "write": {
+                ".rule": {
+                  "write": "true"
+                }
+              }
+            },
+            "cannot": {
+              "write": {
+                ".rule": {
+                  "write": "false"
+                }
+              }
+            }
+          },
+          {
+            "can": {
+              "write": -5
+            },
+            "username": "test_user"
+          },
+          null
+        ]
+      });
     });
 
     it('get with options', async function() {

--- a/__tests__/ain.test.ts
+++ b/__tests__/ain.test.ts
@@ -17,6 +17,11 @@ const {
 
 jest.setTimeout(180000);
 
+function eraseProtoVer(retVal) {
+  retVal.protoVer = 'erased';
+  return retVal;
+}
+
 // TODO (lia): Create more test cases
 describe('ain-js', function() {
   let ain = new Ain(test_node_1);
@@ -718,24 +723,25 @@ describe('ain-js', function() {
     });
 
     it('getValue / getValueRawResult', async function() {
-      expect(await ain.db.ref(allowed_path).getValue()).toMatchObject({
+      expect(await ain.db.ref(allowed_path).getValue()).toEqual({
         "can": {
           "write": -5,
         },
         "username": "test_user",
       });
-      expect(await ain.db.ref(allowed_path).getValueRawResult()).toMatchObject({
+      expect(eraseProtoVer(await ain.db.ref(allowed_path).getValueRawResult())).toEqual({
         "result": {
           "can": {
             "write": -5,
           },
           "username": "test_user",
         },
+        "protoVer": "erased",
       });
     });
 
     it('getRule / getRuleRawResult', async function() {
-      expect(await ain.db.ref(allowed_path).getRule()).toMatchObject({
+      expect(await ain.db.ref(allowed_path).getRule()).toEqual({
         ".rule": {
           "write": "true",
         },
@@ -754,7 +760,7 @@ describe('ain-js', function() {
           },
         },
       });
-      expect(await ain.db.ref(allowed_path).getRuleRawResult()).toMatchObject({
+      expect(eraseProtoVer(await ain.db.ref(allowed_path).getRuleRawResult())).toEqual({
         "result": {
           ".rule": {
             "write": "true",
@@ -774,11 +780,12 @@ describe('ain-js', function() {
             },
           },
         },
+        "protoVer": "erased",
       });
     });
 
     it('getOwner / getOwnerRawResult', async function() {
-      expect(await ain.db.ref(allowed_path).getOwner()).toMatchObject({
+      expect(await ain.db.ref(allowed_path).getOwner()).toEqual({
         ".owner": {
           "owners": {
             "*": {
@@ -796,7 +803,7 @@ describe('ain-js', function() {
           },
         },
       });
-      expect(await ain.db.ref(allowed_path).getOwnerRawResult()).toMatchObject({
+      expect(eraseProtoVer(await ain.db.ref(allowed_path).getOwnerRawResult())).toEqual({
         "result": {
           ".owner": {
             "owners": {
@@ -815,11 +822,12 @@ describe('ain-js', function() {
             },
           },
         },
+        "protoVer": "erased",
       });
     });
 
     it('getFunction / getFunctionRawResult', async function() {
-      expect(await ain.db.ref(allowed_path).getFunction()).toMatchObject({
+      expect(await ain.db.ref(allowed_path).getFunction()).toEqual({
         ".function": {
           "0xFUNCTION_HASH": {
             "function_id": "0xFUNCTION_HASH",
@@ -828,7 +836,7 @@ describe('ain-js', function() {
           },
         },
       });
-      expect(await ain.db.ref(allowed_path).getFunctionRawResult()).toMatchObject({
+      expect(eraseProtoVer(await ain.db.ref(allowed_path).getFunctionRawResult())).toEqual({
         "result": {
           ".function": {
             "0xFUNCTION_HASH": {
@@ -838,6 +846,7 @@ describe('ain-js', function() {
             },
           },
         },
+        "protoVer": "erased",
       });
     });
 
@@ -856,7 +865,7 @@ describe('ain-js', function() {
             ref: 'deeper/path/'
           }
         ]
-      )).toMatchObject([
+      )).toEqual([
         {
           ".rule": {
             "write": "true"
@@ -884,7 +893,7 @@ describe('ain-js', function() {
         },
         null
       ]);
-      expect(await ain.db.ref(allowed_path).getRawResult(
+      expect(eraseProtoVer(await ain.db.ref(allowed_path).getRawResult(
         [
           {
             type: 'GET_RULE',
@@ -898,7 +907,7 @@ describe('ain-js', function() {
             ref: 'deeper/path/'
           }
         ]
-      )).toMatchObject({
+      ))).toEqual({
         "result": [
           {
             ".rule": {
@@ -926,7 +935,31 @@ describe('ain-js', function() {
             "username": "test_user"
           },
           null
-        ]
+        ],
+        "protoVer": "erased",
+      });
+    });
+
+    it('get / getRawResult with error', async function() {
+      expect(eraseProtoVer(await ain.db.ref(allowed_path).get([ // empty op_list
+      ]))).toEqual({
+        "code": 30006,
+        "error": {
+          "code": 30006,
+          "message": "Invalid op_list given",
+        },
+        "protoVer": "erased",
+        "result": null,
+      });
+      expect(eraseProtoVer(await ain.db.ref(allowed_path).getRawResult([ // empty op_list
+      ]))).toEqual({
+        "code": 30006,
+        "error": {
+          "code": 30006,
+          "message": "Invalid op_list given",
+        },
+        "protoVer": "erased",
+        "result": null,
       });
     });
 

--- a/__tests__/ain.test.ts
+++ b/__tests__/ain.test.ts
@@ -717,14 +717,14 @@ describe('ain-js', function() {
       });
     });
 
-    it('getValue / getValueV2', async function() {
+    it('getValue / getValueRawResult', async function() {
       expect(await ain.db.ref(allowed_path).getValue()).toMatchObject({
         "can": {
           "write": -5,
         },
         "username": "test_user",
       });
-      expect(await ain.db.ref(allowed_path).getValueV2()).toMatchObject({
+      expect(await ain.db.ref(allowed_path).getValueRawResult()).toMatchObject({
         "result": {
           "can": {
             "write": -5,
@@ -734,7 +734,7 @@ describe('ain-js', function() {
       });
     });
 
-    it('getRule / getRuleV2', async function() {
+    it('getRule / getRuleRawResult', async function() {
       expect(await ain.db.ref(allowed_path).getRule()).toMatchObject({
         ".rule": {
           "write": "true",
@@ -754,7 +754,7 @@ describe('ain-js', function() {
           },
         },
       });
-      expect(await ain.db.ref(allowed_path).getRuleV2()).toMatchObject({
+      expect(await ain.db.ref(allowed_path).getRuleRawResult()).toMatchObject({
         "result": {
           ".rule": {
             "write": "true",
@@ -777,7 +777,7 @@ describe('ain-js', function() {
       });
     });
 
-    it('getOwner / getOwnerV2', async function() {
+    it('getOwner / getOwnerRawResult', async function() {
       expect(await ain.db.ref(allowed_path).getOwner()).toMatchObject({
         ".owner": {
           "owners": {
@@ -796,7 +796,7 @@ describe('ain-js', function() {
           },
         },
       });
-      expect(await ain.db.ref(allowed_path).getOwnerV2()).toMatchObject({
+      expect(await ain.db.ref(allowed_path).getOwnerRawResult()).toMatchObject({
         "result": {
           ".owner": {
             "owners": {
@@ -818,7 +818,7 @@ describe('ain-js', function() {
       });
     });
 
-    it('getFunction / getFunctionV2', async function() {
+    it('getFunction / getFunctionRawResult', async function() {
       expect(await ain.db.ref(allowed_path).getFunction()).toMatchObject({
         ".function": {
           "0xFUNCTION_HASH": {
@@ -828,7 +828,7 @@ describe('ain-js', function() {
           },
         },
       });
-      expect(await ain.db.ref(allowed_path).getFunctionV2()).toMatchObject({
+      expect(await ain.db.ref(allowed_path).getFunctionRawResult()).toMatchObject({
         "result": {
           ".function": {
             "0xFUNCTION_HASH": {
@@ -841,7 +841,7 @@ describe('ain-js', function() {
       });
     });
 
-    it('get / getV2', async function() {
+    it('get / getRawResult', async function() {
       expect(await ain.db.ref(allowed_path).get(
         [
           {
@@ -884,7 +884,7 @@ describe('ain-js', function() {
         },
         null
       ]);
-      expect(await ain.db.ref(allowed_path).getV2(
+      expect(await ain.db.ref(allowed_path).getRawResult(
         [
           {
             type: 'GET_RULE',

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "test": "jest",
     "test_snapshot": "jest --updateSnapshot",
     "test_ain": "jest ain.test.ts",
+    "test_ain_snapshot": "jest ain.test.ts --updateSnapshot",
     "test_he": "jest he.test.ts",
     "test_em": "jest event_manager.test.ts"
   },

--- a/src/ain-db/ref.ts
+++ b/src/ain-db/ref.ts
@@ -100,7 +100,7 @@ export default class Reference {
   }
 
   /**
-   * The same as getValue() except returning raw result.
+   * The same as getRule() except returning raw result.
    */
   getRuleRawResult(path?: string, options?: GetOptions): Promise<any> {
     const req = Reference.buildGetRequest('GET_RULE', Reference.extendPath(this.path, path), options);
@@ -117,7 +117,7 @@ export default class Reference {
   }
 
   /**
-   * The same as getValue() except returning raw result.
+   * The same as getOwner() except returning raw result.
    */
   getOwnerRawResult(path?: string, options?: GetOptions): Promise<any> {
     const req = Reference.buildGetRequest('GET_OWNER', Reference.extendPath(this.path, path), options);
@@ -134,7 +134,7 @@ export default class Reference {
   }
 
   /**
-   * The same as getValue() except returning raw result.
+   * The same as getFunction() except returning raw result.
    */
   getFunctionRawResult(path?: string, options?: GetOptions): Promise<any> {
     const req = Reference.buildGetRequest('GET_FUNCTION', Reference.extendPath(this.path, path), options);
@@ -156,7 +156,7 @@ export default class Reference {
   }
 
   /**
-   * The same as getValue() except returning raw result.
+   * The same as get() except returning raw result.
    */
   getRawResult(gets: GetOperation[]): Promise<any> {
     let request = { type: 'GET', op_list: gets }

--- a/src/ain-db/ref.ts
+++ b/src/ain-db/ref.ts
@@ -83,12 +83,28 @@ export default class Reference {
   }
 
   /**
+   * The same as getValue() except using blockchain API v2 (ain_getV2) for result-error separation.
+   */
+  getValueV2(path?: string, options?: GetOptions): Promise<any> {
+    const req = Reference.buildGetRequest('GET_VALUE', Reference.extendPath(this.path, path), options);
+    return this._ain.provider.send('ain_getV2', req);
+  }
+
+  /**
    * Returns the rule at the path.
    * @param path
    */
   getRule(path?: string, options?: GetOptions): Promise<any> {
     const req = Reference.buildGetRequest('GET_RULE', Reference.extendPath(this.path, path), options);
     return this._ain.provider.send('ain_get', req);
+  }
+
+  /**
+   * The same as getRule() except using blockchain API v2 (ain_getV2) for result-error separation.
+   */
+  getRuleV2(path?: string, options?: GetOptions): Promise<any> {
+    const req = Reference.buildGetRequest('GET_RULE', Reference.extendPath(this.path, path), options);
+    return this._ain.provider.send('ain_getV2', req);
   }
 
   /**
@@ -101,12 +117,28 @@ export default class Reference {
   }
 
   /**
+   * The same as getOwner() except using blockchain API v2 (ain_getV2) for result-error separation.
+   */
+  getOwnerV2(path?: string, options?: GetOptions): Promise<any> {
+    const req = Reference.buildGetRequest('GET_OWNER', Reference.extendPath(this.path, path), options);
+    return this._ain.provider.send('ain_getV2', req);
+  }
+
+  /**
    * Returns the function config at the path.
    * @param path
    */
   getFunction(path?: string, options?: GetOptions): Promise<any> {
     const req = Reference.buildGetRequest('GET_FUNCTION', Reference.extendPath(this.path, path), options);
     return this._ain.provider.send('ain_get', req);
+  }
+
+  /**
+   * The same as getFunction() except using blockchain API v2 (ain_getV2) for result-error separation.
+   */
+  getFunctionV2(path?: string, options?: GetOptions): Promise<any> {
+    const req = Reference.buildGetRequest('GET_FUNCTION', Reference.extendPath(this.path, path), options);
+    return this._ain.provider.send('ain_getV2', req);
   }
 
   /**
@@ -121,6 +153,17 @@ export default class Reference {
       request.op_list[i].ref = Reference.extendPath(this.path, gets[i].ref);
     }
     return this._ain.provider.send('ain_get', request);
+  }
+
+  /**
+   * The same as get() except using blockchain API v2 (ain_getV2) for result-error separation.
+   */
+  getV2(gets: GetOperation[]): Promise<any> {
+    let request = { type: 'GET', op_list: gets }
+    for (let i = 0; i < gets.length; i++) {
+      request.op_list[i].ref = Reference.extendPath(this.path, gets[i].ref);
+    }
+    return this._ain.provider.send('ain_getV2', request);
   }
 
   /**

--- a/src/ain-db/ref.ts
+++ b/src/ain-db/ref.ts
@@ -83,11 +83,11 @@ export default class Reference {
   }
 
   /**
-   * The same as getValue() except using blockchain API v2 (ain_getV2) for result-error separation.
+   * The same as getValue() except returning raw result.
    */
-  getValueV2(path?: string, options?: GetOptions): Promise<any> {
+  getValueRawResult(path?: string, options?: GetOptions): Promise<any> {
     const req = Reference.buildGetRequest('GET_VALUE', Reference.extendPath(this.path, path), options);
-    return this._ain.provider.send('ain_getV2', req);
+    return this._ain.provider.sendForRawResult('ain_get', req);
   }
 
   /**
@@ -100,11 +100,11 @@ export default class Reference {
   }
 
   /**
-   * The same as getRule() except using blockchain API v2 (ain_getV2) for result-error separation.
+   * The same as getValue() except returning raw result.
    */
-  getRuleV2(path?: string, options?: GetOptions): Promise<any> {
+  getRuleRawResult(path?: string, options?: GetOptions): Promise<any> {
     const req = Reference.buildGetRequest('GET_RULE', Reference.extendPath(this.path, path), options);
-    return this._ain.provider.send('ain_getV2', req);
+    return this._ain.provider.sendForRawResult('ain_get', req);
   }
 
   /**
@@ -117,11 +117,11 @@ export default class Reference {
   }
 
   /**
-   * The same as getOwner() except using blockchain API v2 (ain_getV2) for result-error separation.
+   * The same as getValue() except returning raw result.
    */
-  getOwnerV2(path?: string, options?: GetOptions): Promise<any> {
+  getOwnerRawResult(path?: string, options?: GetOptions): Promise<any> {
     const req = Reference.buildGetRequest('GET_OWNER', Reference.extendPath(this.path, path), options);
-    return this._ain.provider.send('ain_getV2', req);
+    return this._ain.provider.sendForRawResult('ain_get', req);
   }
 
   /**
@@ -134,11 +134,11 @@ export default class Reference {
   }
 
   /**
-   * The same as getFunction() except using blockchain API v2 (ain_getV2) for result-error separation.
+   * The same as getValue() except returning raw result.
    */
-  getFunctionV2(path?: string, options?: GetOptions): Promise<any> {
+  getFunctionRawResult(path?: string, options?: GetOptions): Promise<any> {
     const req = Reference.buildGetRequest('GET_FUNCTION', Reference.extendPath(this.path, path), options);
-    return this._ain.provider.send('ain_getV2', req);
+    return this._ain.provider.sendForRawResult('ain_get', req);
   }
 
   /**
@@ -156,14 +156,14 @@ export default class Reference {
   }
 
   /**
-   * The same as get() except using blockchain API v2 (ain_getV2) for result-error separation.
+   * The same as getValue() except returning raw result.
    */
-  getV2(gets: GetOperation[]): Promise<any> {
+  getRawResult(gets: GetOperation[]): Promise<any> {
     let request = { type: 'GET', op_list: gets }
     for (let i = 0; i < gets.length; i++) {
       request.op_list[i].ref = Reference.extendPath(this.path, gets[i].ref);
     }
-    return this._ain.provider.send('ain_getV2', request);
+    return this._ain.provider.sendForRawResult('ain_get', request);
   }
 
   /**

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -33,16 +33,8 @@ export default class Provider {
    * @return {Promise<any>}
    */
   async send(rpcMethod: string, params?: any): Promise<any> {
-    const data = {
-      jsonrpc: "2.0",
-      method: rpcMethod,
-      params: Object.assign(params || {}, { protoVer: this.ain.net.protoVer }),
-      id: 0
-    };
-    const response = await this.httpClient.post(this.apiEndpoint, data);
-    const result = get(response, 'data.result.result', null);
-    const code = get(response, 'data.result.code');
-    return code !== undefined ? get(response, 'data.result') : result;
+    const rawResult = await this.sendForRawResult(rpcMethod, params);
+    return rawResult.code !== undefined ? rawResult : get(rawResult, 'result', null);
   }
 
   /**

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -46,6 +46,20 @@ export default class Provider {
   }
 
   /**
+   * The same as getValue() except returning raw result.
+   */
+  async sendForRawResult(rpcMethod: string, params?: any): Promise<any> {
+    const data = {
+      jsonrpc: "2.0",
+      method: rpcMethod,
+      params: Object.assign(params || {}, { protoVer: this.ain.net.protoVer }),
+      id: 0
+    };
+    const response = await this.httpClient.post(this.apiEndpoint, data);
+    return get(response, 'data.result');
+  }
+
+  /**
    * Sets the httpClient's default timeout time
    * @param {number} time (in milliseconds)
    */


### PR DESCRIPTION
Change summary:
- Add get*RawResult() methods to support merged v1 and v2 blockchain get APIs
- Check in test snapshots
- Use toEqual() for some cases and add more test cases

Related issues:
- https://github.com/ainblockchain/ain-blockchain/issues/1053