### PR TITLE
Support simplify result format of not using 'error' property

### DIFF
--- a/__tests__/ain.test.ts
+++ b/__tests__/ain.test.ts
@@ -944,20 +944,14 @@ describe('ain-js', function() {
       expect(eraseProtoVer(await ain.db.ref(allowed_path).get([ // empty op_list
       ]))).toEqual({
         "code": 30006,
-        "error": {
-          "code": 30006,
-          "message": "Invalid op_list given",
-        },
+        "message": "Invalid op_list given",
         "protoVer": "erased",
         "result": null,
       });
       expect(eraseProtoVer(await ain.db.ref(allowed_path).getRawResult([ // empty op_list
       ]))).toEqual({
         "code": 30006,
-        "error": {
-          "code": 30006,
-          "message": "Invalid op_list given",
-        },
+        "message": "Invalid op_list given",
         "protoVer": "erased",
         "result": null,
       });


### PR DESCRIPTION
Change summary:
- Support simplify result format of not using 'error' property

Related PR: 
- https://github.com/ainblockchain/ain-blockchain/pull/1066

Related issues:
- https://github.com/ainblockchain/ain-blockchain/issues/1053