### PR TITLE
Use Error throwing instead of is_raw_result_request option

### DIFF
--- a/__tests__/ain.test.ts
+++ b/__tests__/ain.test.ts
@@ -69,14 +69,14 @@ describe('ain-js', function() {
       ain.net.checkProtocolVersion()
       .then(res => {
         expect(res.code).toBe(0);
-        expect(res.result).toBe('Success');
+        expect(res.result).toBe(true);
         done();
       })
       .catch(e => {
         console.log("ERROR:", e)
         done();
       })
-    })
+    });
   });
 
   describe('Wallet', function() {
@@ -360,16 +360,19 @@ describe('ain-js', function() {
     //   expect(await ain.getTransactionResult('0xabcdefghijklmnop')).toMatchSnapshot();
     // });
 
-    it('validateAppName', async function () {
-      expect(await ain.validateAppName('test')).toStrictEqual({
-        "is_valid": false,
-        "code": 30603,
-        "message": "App name already in use: test",
-      });
-      expect(await ain.validateAppName('test_new')).toStrictEqual({
+    it('validateAppName returns true', async function () {
+      expect(eraseProtoVer(await ain.validateAppName('test_new'))).toStrictEqual({
         "is_valid": true,
+        "result": true,
         "code": 0,
+        "protoVer": "erased",
       });
+    });
+
+    it('validateAppName returns false', async function () {
+      await expect(() => ain.validateAppName('app/path'))
+          .rejects
+          .toThrow(/"is_valid":false,"result":false,"code":30601,"message":"Invalid app name for state label: app\/path"/);
     });
 
     it('sendTransaction', function(done) {

--- a/__tests__/ain.test.ts
+++ b/__tests__/ain.test.ts
@@ -370,9 +370,14 @@ describe('ain-js', function() {
     });
 
     it('validateAppName returns false', async function () {
-      await expect(() => ain.validateAppName('app/path'))
-          .rejects
-          .toThrow(/"is_valid":false,"result":false,"code":30601,"message":"Invalid app name for state label: app\/path"/);
+      let thrownError;
+      try {
+        await ain.validateAppName('app/path');
+      } catch(err) {
+        thrownError = err;
+      }
+      expect(thrownError.code).toEqual(30601);
+      expect(thrownError.message).toEqual('Invalid app name for state label: app/path');
     });
 
     it('sendTransaction', function(done) {
@@ -455,9 +460,14 @@ describe('ain-js', function() {
       }
       const sig = '';  // Invalid signature value
 
-      await expect(() => ain.sendSignedTransaction(sig, tx))
-          .rejects
-          .toThrow(/"result":null,"code":30302,"message":"Missing properties."/);
+      let thrownError;
+      try {
+        await ain.sendSignedTransaction(sig, tx);
+      } catch(err) {
+        thrownError = err;
+      }
+      expect(thrownError.code).toEqual(30302);
+      expect(thrownError.message).toEqual('Missing properties.');
     });
 
     it('sendTransactionBatch', function(done) {
@@ -568,9 +578,14 @@ describe('ain-js', function() {
     });
 
     it('sendTransactionBatch with empty tx_list', async function() {
-      await expect(() => ain.sendTransactionBatch([]))
-          .rejects
-          .toThrow(/"result":null,"code":30401,"message":"Invalid batch transaction format."/);
+      let thrownError;
+      try {
+        await ain.sendTransactionBatch([]);
+      } catch(err) {
+        thrownError = err;
+      }
+      expect(thrownError.code).toEqual(30401);
+      expect(thrownError.message).toEqual('Invalid batch transaction format.');
     });
   });
 
@@ -834,9 +849,14 @@ describe('ain-js', function() {
     });
 
     it('get with empty op_list', async function() {
-      await expect(() => ain.db.ref(allowed_path).get([]))
-          .rejects
-          .toThrow(/"result":null,"code":30006,"message":"Invalid op_list given"/);
+      let thrownError;
+      try {
+        await ain.db.ref(allowed_path).get([]);
+      } catch(err) {
+        thrownError = err;
+      }
+      expect(thrownError.code).toEqual(30006);
+      expect(thrownError.message).toEqual('Invalid op_list given');
     });
 
     it('get with options', async function() {

--- a/src/ain-db/ref.ts
+++ b/src/ain-db/ref.ts
@@ -115,9 +115,8 @@ export default class Reference {
    * Could be any one from "VALUE", "RULE", "OWNER", "FUNC" or a combination of them as an array.
    * @return {Promise<any>}
    */
-  // TODO(platfowner): Remove isRawResultRequest param once migration is completed.
-  get(gets: GetOperation[], isRawResultRequest: boolean = false): Promise<any> {
-    const request = { type: 'GET', op_list: gets, is_raw_result_request: isRawResultRequest };
+  get(gets: GetOperation[]): Promise<any> {
+    const request = { type: 'GET', op_list: gets };
     for (let i = 0; i < gets.length; i++) {
       request.op_list[i].ref = Reference.extendPath(this.path, gets[i].ref);
     }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,0 +1,13 @@
+export class BlockchainError extends Error {
+  public code: number;
+
+  constructor(code: number, message: string) {
+    super(message);
+    // NOTE(platfowner): https://stackoverflow.com/questions/68899615/how-to-expect-a-custom-error-to-be-thrown-with-jest
+    Object.setPrototypeOf(this, BlockchainError.prototype);
+
+    this.name = this.constructor.name;
+    this.code = code;
+    this.message = message;
+  }
+}

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -41,11 +41,10 @@ export default class Provider {
     };
     const response = await this.httpClient.post(this.apiEndpoint, data);
     const rawResult = get(response, 'data.result');
-    // TODO(platfowner): Remove this block once migration is completed.
-    if (!data.params.is_raw_result_request) {
-      return rawResult.code !== undefined ? rawResult : get(rawResult, 'result', null);
+    if (typeof rawResult !== 'object' || !(rawResult.code === undefined || rawResult.code === 0)) {
+      throw new Error(JSON.stringify(rawResult));
     }
-    return rawResult;
+    return rawResult.code !== undefined ? rawResult : get(rawResult, 'result', null);
   }
 
   /**

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -2,6 +2,8 @@ import axios, { AxiosInstance } from 'axios';
 import * as parseUrl from 'url-parse';
 import { get } from 'lodash';
 import Ain from './ain';
+import { BlockchainError } from './errors';
+
 const JSON_RPC_ENDPOINT = 'json-rpc';
 
 export default class Provider {
@@ -42,7 +44,7 @@ export default class Provider {
     const response = await this.httpClient.post(this.apiEndpoint, data);
     const rawResult = get(response, 'data.result');
     if (typeof rawResult !== 'object' || !(rawResult.code === undefined || rawResult.code === 0)) {
-      throw new Error(JSON.stringify(rawResult));
+      throw new BlockchainError(rawResult.code, rawResult.message);
     }
     return rawResult.code !== undefined ? rawResult : get(rawResult, 'result', null);
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -59,14 +59,12 @@ export type GetOperationType = "GET_VALUE" | "GET_RULE" | "GET_OWNER" | "GET_FUN
 export type OwnerPermission = "branch_owner" | "write_function" | "write_owner" | "write_rule";
 
 export type GetOptions = {
-  is_global?: boolean,
-  is_final?: boolean,
-  is_shallow?: boolean,
-  // TODO(platfowner): Remove this option once migration is completed.
-  is_raw_result_request?: boolean,
-  include_version?: boolean,
-  include_tree_info?: boolean,
-  include_proof?: boolean,
+  is_global?: boolean;
+  is_final?: boolean;
+  is_shallow?: boolean;
+  include_version?: boolean;
+  include_tree_info?: boolean;
+  include_proof?: boolean;
 }
 
 export interface SetOperation {
@@ -141,79 +139,79 @@ export interface TransactionInfo {
   index: number;
   timestamp: number;
   is_finalized: boolean;
-  finalized_at: number
+  finalized_at: number;
 }
 
 export interface TransactionResult {
-  status: boolean,
-  block_hash?: string,
-  block_number?: number,
-  hash: string,
-  index?: number,
-  address: string,
-  parent_tx_hash?: string
+  status: boolean;
+  block_hash?: string;
+  block_number?: number;
+  hash: string;
+  index?: number;
+  address: string;
+  parent_tx_hash?: string;
 }
 
 export interface Block {
-  number: number,
-  epoch: number,
-  hash: string,
-  last_hash: string,
-  proposer: string,
-  validators: any,
-  size: number,
-  timestamp: number,
-  transactions: Transaction[],
-  last_votes: Transaction[],
-  stateProofHash: string,
-  last_votes_hash: string,
-  transactions_hash: string
+  number: number;
+  epoch: number;
+  hash: string;
+  last_hash: string;
+  proposer: string;
+  validators: any;
+  size: number;
+  timestamp: number;
+  transactions: Transaction[];
+  last_votes: Transaction[];
+  stateProofHash: string;
+  last_votes_hash: string;
+  transactions_hash: string;
 }
 
 export interface ListenerMap {
-  [key: string]: Function[]
+  [key: string]: Function[];
 }
 
 export interface EvalRuleInput {
-  value: any,
-  ref?: string,
-  address?: string,
-  timestamp?: number,
-  is_global?: boolean
+  value: any;
+  ref?: string;
+  address?: string;
+  timestamp?: number;
+  is_global?: boolean;
 }
 
 export interface EvalOwnerInput {
-  ref?: string,
-  address?: string,
-  permission: OwnerPermission,
-  is_global?: boolean
+  ref?: string;
+  address?: string;
+  permission: OwnerPermission;
+  is_global?: boolean;
 }
 
 export interface MatchInput {
-  ref?: string,
-  is_global?: boolean
+  ref?: string;
+  is_global?: boolean;
 }
 
 export interface StateUsageInfo {
-  tree_height?: number,
-  tree_size?: number,
-  tree_bytes?: number,
+  tree_height?: number;
+  tree_size?: number;
+  tree_bytes?: number;
 }
 
 export interface AppNameValidationInfo {
-  is_valid: boolean,
-  code: number,
-  message?: string,
+  is_valid: boolean;
+  code: number;
+  message?: string;
 }
 
 export type HomomorphicEncryptionParams = {
-  polyModulusDegree: number,
-  coeffModulusArray: Int32Array,
-  scaleBit: number
+  polyModulusDegree: number;
+  coeffModulusArray: Int32Array;
+  scaleBit: number;
 }
 
 export type HomomorphicEncryptionSecretKey = {
-  secretKey: string
+  secretKey: string;
 }
 
 export enum BlockchainEventTypes {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,39 +1,39 @@
 export interface Account {
-  address: string,
-  private_key: string,
-  public_key: string
+  address: string;
+  private_key: string;
+  public_key: string;
 }
 
 export interface Accounts {[address: string]: Account}
 
 export interface KdfParams {
-  dklen: number,
-  salt: string,
-  prf?: string,
-  c?: number,
-  n?: number,
-  r?: number,
-  p?: number
+  dklen: number;
+  salt: string;
+  prf?: string;
+  c?: number;
+  n?: number;
+  r?: number;
+  p?: number;
 }
 
 export interface V3KeystoreOptions {
-  salt?: string,
-  iv?: Buffer,
-  kdf?: string,
-  dklen?: number,
-  c?: number,
-  n?: number,
-  r?: number,
-  p?: number,
-  prf?: string,
-  cipher?: string,
-  uuid?: Buffer
+  salt?: string;
+  iv?: Buffer;
+  kdf?: string;
+  dklen?: number;
+  c?: number;
+  n?: number;
+  r?: number;
+  p?: number;
+  prf?: string;
+  cipher?: string;
+  uuid?: Buffer;
 }
 
 export interface V3Keystore {
-  version: 3,
-  id: string,
-  address: string,
+  version: 3;
+  id: string;
+  address: string;
   crypto: {
     ciphertext: string,
     cipherparams: {
@@ -43,7 +43,7 @@ export interface V3Keystore {
     kdf: string,
     kdfparams: KdfParams,
     mac: string
-  }
+  };
 }
 
 // export type EventType = "value" | "child_added" | "child_changed" | "child_removed";


### PR DESCRIPTION
Change summary:
- Use Error throwing instead of is_raw_result_request option
- Update tests for latest json rpc API result format changes

Related PRs:
- https://github.com/ainblockchain/ain-blockchain/pull/1070

Related issues:
- https://github.com/ainblockchain/ain-blockchain/issues/1053