### PR TITLE
Support rawResultMode = true option in Ain class

### DIFF
--- a/__tests__/ain.test.ts
+++ b/__tests__/ain.test.ts
@@ -4,8 +4,6 @@ import { TransactionBody, SetOperation, Transaction, TransactionInput, SetOperat
 import { createSecretKey } from 'crypto';
 import { anyTypeAnnotation } from '@babel/types';
 import axios from 'axios';
-const TEST_STRING = 'test_string';
-const TX_PATTERN = /^0x([A-Fa-f0-9]{64})$/;
 const {
   test_keystore,
   test_pw,
@@ -14,6 +12,9 @@ const {
   test_node_1,
   test_node_2
 } = require('./test_data');
+
+const TEST_STRING = 'test_string';
+const TX_PATTERN = /^0x([A-Fa-f0-9]{64})$/;
 
 jest.setTimeout(180000);
 
@@ -53,28 +54,26 @@ describe('ain-js', function() {
       expect(await ain.net.isSyncing()).toBe(false);
     });
 
-    it('getProtocolVersion', function(done) {
-      ain.net.getProtocolVersion()
+    it('getProtocolVersion', async function() {
+      await ain.net.getProtocolVersion()
       .then(res => {
         expect(res).not.toBeNull();
-        done();
       })
       .catch(e => {
         console.log("ERROR:", e);
-        done();
+        fail();
       })
     });
 
-    it('checkProtocolVersion', function(done) {
-      ain.net.checkProtocolVersion()
+    it('checkProtocolVersion', async function() {
+      await ain.net.checkProtocolVersion()
       .then(res => {
         expect(res.code).toBe(0);
         expect(res.result).toBe(true);
-        done();
       })
       .catch(e => {
         console.log("ERROR:", e)
-        done();
+        fail();
       })
     });
   });
@@ -380,17 +379,16 @@ describe('ain-js', function() {
       expect(thrownError.message).toEqual('Invalid app name for state label: app/path');
     });
 
-    it('sendTransaction', function(done) {
-      ain.sendTransaction({ operation: targetTx })
+    it('sendTransaction', async function() {
+      await ain.sendTransaction({ operation: targetTx })
       .then(res => {
         expect(res.result.code).toBe(0);
         expect(res.tx_hash).toEqual(expect.stringMatching(TX_PATTERN));
         targetTxHash = res.tx_hash;
-        done();
       })
       .catch(e => {
         console.log("ERROR:", e)
-        done();
+        fail();
       })
     });
 
@@ -400,7 +398,7 @@ describe('ain-js', function() {
     });
 
 
-    it('sendSignedTransaction', function(done) {
+    it('sendSignedTransaction', async function() {
       const tx: TransactionBody = {
         nonce: -1,
         gas_price: 500,
@@ -424,15 +422,14 @@ describe('ain-js', function() {
       }
       const sig = ain.wallet.signTransaction(tx);
 
-      ain.sendSignedTransaction(sig, tx)
+      await ain.sendSignedTransaction(sig, tx)
       .then(res => {
         expect(res.result.code).toBe(0);
         expect(res.tx_hash).toEqual(expect.stringMatching(TX_PATTERN));
-        done();
       })
       .catch(e => {
-        console.log("ERROR:", e)
-        done();
+        console.log("ERROR:", e);
+        fail();
       })
     });
 
@@ -470,7 +467,7 @@ describe('ain-js', function() {
       expect(thrownError.message).toEqual('Missing properties.');
     });
 
-    it('sendTransactionBatch', function(done) {
+    it('sendTransactionBatch', async function() {
       const tx1: TransactionInput = {
         operation: {
           type: 'SET_VALUE',
@@ -555,7 +552,7 @@ describe('ain-js', function() {
         address: addr2
       }
 
-      ain.sendTransactionBatch([ tx1, tx2, tx3, tx4, tx5, tx6 ])
+      await ain.sendTransactionBatch([ tx1, tx2, tx3, tx4, tx5, tx6 ])
       .then(res => {
         expect(res[0].result.code).toBe(12103);
         expect(res[0].tx_hash).toEqual(expect.stringMatching(TX_PATTERN));
@@ -569,11 +566,10 @@ describe('ain-js', function() {
         expect(res[4].tx_hash).toEqual(expect.stringMatching(TX_PATTERN));
         expect(res[5].result.code).toBe(12302);
         expect(res[5].tx_hash).toEqual(expect.stringMatching(TX_PATTERN));
-        done();
       })
       .catch(e => {
-        console.log("ERROR:", e)
-        done();
+        console.log("ERROR:", e);
+        fail();
       })
     });
 
@@ -603,8 +599,8 @@ describe('ain-js', function() {
       expect(ain.db.ref(test_path).path).toBe('/' + test_path);
     });
 
-    it('setOwner', function(done) {
-      ain.db.ref(allowed_path).setOwner({
+    it('setOwner', async function() {
+      await ain.db.ref(allowed_path).setOwner({
         value: {
           ".owner": {
               "owners": {
@@ -620,16 +616,15 @@ describe('ain-js', function() {
       })
       .then(res => {
         expect(res.result.code).toBe(0);
-        done();
       })
       .catch((error) => {
         console.log("setOwner error:", error);
-        done();
+        fail();
       });
     });
 
-    it('should fail to setOwner', function(done) {
-      ain.db.ref('/consensus').setOwner({
+    it('should fail to setOwner', async function() {
+      await ain.db.ref('/consensus').setOwner({
         value: {
           ".owner": {
               "owners": {
@@ -645,44 +640,41 @@ describe('ain-js', function() {
       })
       .then(res => {
         expect(res.result.code).toBe(12501);
-        done();
       })
       .catch((error) => {
         console.log("setOwner error:", error);
-        done();
+        fail();
       });
     });
 
-    it('setRule', function(done) {
-      ain.db.ref(allowed_path).setRule({
+    it('setRule', async function() {
+      await ain.db.ref(allowed_path).setRule({
         value: { '.rule': { 'write': "true" } }
       })
       .then(res => {
         expect(res.result.code).toBe(0);
-        done();
       })
       .catch((error) => {
         console.log("setRule error:", error);
-        done();
+        fail();
       });
     });
 
-    it('setValue', function(done) {
-      ain.db.ref(allowed_path + '/username').setValue({
+    it('setValue', async function() {
+      await ain.db.ref(allowed_path + '/username').setValue({
         value: "test_user"
       })
       .then(res => {
         expect(res.result.code).toBe(0);
-        done();
       })
       .catch((error) => {
         console.log("setValue error:", error);
-        done();
+        fail();
       });
     });
 
-    it('setFunction', function(done) {
-      ain.db.ref(allowed_path).setFunction({
+    it('setFunction', async function() {
+      await ain.db.ref(allowed_path).setFunction({
           value: {
             ".function": {
               '0xFUNCTION_HASH': {
@@ -695,16 +687,15 @@ describe('ain-js', function() {
         })
         .then(res => {
           expect(res.result.code).toBe(0);
-          done();
         })
         .catch((error) => {
           console.log("setFunction error:", error);
-          done();
+          fail();
         })
     });
 
-    it('set', function(done) {
-      ain.db.ref(allowed_path).set({
+    it('set', async function() {
+      await ain.db.ref(allowed_path).set({
         op_list: [
           {
             type: 'SET_RULE',
@@ -731,11 +722,10 @@ describe('ain-js', function() {
       })
       .then(res => {
         expect(Object.keys(res.result).length).toBe(4);
-        done();
       })
       .catch((error) => {
         console.log("set error:",error);
-        done();
+        fail();
       });
     });
 
@@ -869,87 +859,80 @@ describe('ain-js', function() {
       expect(getWithVersion['#version']).not.toBeNull();
     });
 
-    it('deleteValue', function(done) {
-      ain.db.ref(`${allowed_path}/can/write`).deleteValue()
+    it('deleteValue', async function() {
+      await ain.db.ref(`${allowed_path}/can/write`).deleteValue()
       .then(res => {
         expect(res.result.code).toBe(0);
-        done();
       })
       .catch((error) => {
         console.log("deleteValue error:",error);
-        done();
+        fail();
       });
     });
 
-    it('evalRule: true', function(done) {
-      ain.db.ref(allowed_path).evalRule({ ref: '/can/write', value: 'hi' })
+    it('evalRule: true', async function() {
+      await ain.db.ref(allowed_path).evalRule({ ref: '/can/write', value: 'hi' })
       .then(res => {
         expect(res).toStrictEqual({"code": 0, "matched": {"state": {"closestRule": {"config": null, "path": []}, "matchedRulePath": ["apps", "bfan", "users", "0x09A0d53FDf1c36A131938eb379b98910e55EEfe1", "can", "write"], "matchedValuePath": ["apps", "bfan", "users", "0x09A0d53FDf1c36A131938eb379b98910e55EEfe1", "can", "write"], "pathVars": {}}, "write": {"closestRule": {"config": {"write": "true"}, "path": ["apps", "bfan", "users", "0x09A0d53FDf1c36A131938eb379b98910e55EEfe1", "can", "write"]}, "matchedRulePath": ["apps", "bfan", "users", "0x09A0d53FDf1c36A131938eb379b98910e55EEfe1", "can", "write"], "matchedValuePath": ["apps", "bfan", "users", "0x09A0d53FDf1c36A131938eb379b98910e55EEfe1", "can", "write"], "pathVars": {}, "subtreeRules": []}}});
-        done();
       })
       .catch(error => {
         console.log("error:", error);
-        done();
+        fail();
       })
     });
 
-    it('evalRule: false', function(done) {
-      ain.db.ref(allowed_path).evalRule({ ref: '/cannot/write', value: 'hi' })
+    it('evalRule: false', async function() {
+      await ain.db.ref(allowed_path).evalRule({ ref: '/cannot/write', value: 'hi' })
       .then(res => {
         expect(res.code).toBe(12103);
-        done();
       })
       .catch(error => {
         console.log("error:", error);
-        done();
+        fail();
       })
     });
 
-    it('evalOwner', function(done) {
-      ain.db.ref(allowed_path).evalOwner({ permission: "branch_owner" })
+    it('evalOwner', async function() {
+      await ain.db.ref(allowed_path).evalOwner({ permission: "branch_owner" })
       .then(res => {
         expect(res).toMatchSnapshot();
-        done();
       })
       .catch(error => {
         console.log("error:", error);
-        done();
+        fail();
       })
     });
 
-    it('matchFunction', function(done) {
-      ain.db.ref(allowed_path).matchFunction()
+    it('matchFunction', async function() {
+      await ain.db.ref(allowed_path).matchFunction()
       .then(res => {
         expect(res).toMatchSnapshot();
-        done();
       })
       .catch(error => {
         console.log("error:", error);
-        done();
+        fail();
       })
     });
 
-    it('matchRule', function(done) {
-      ain.db.ref(allowed_path).matchRule()
+    it('matchRule', async function() {
+      await ain.db.ref(allowed_path).matchRule()
       .then(res => {
         expect(res).toMatchSnapshot();
-        done();
       })
       .catch(error => {
         console.log("error:", error);
-        done();
+        fail();
       })
     });
 
-    it('matchOwner', function(done) {
-      ain.db.ref(allowed_path).matchOwner()
+    it('matchOwner', async function() {
+      await ain.db.ref(allowed_path).matchOwner()
       .then(res => {
         expect(res).toMatchSnapshot();
-        done();
       })
       .catch(error => {
         console.log("error:", error);
-        done();
+        fail();
       })
     });
 

--- a/__tests__/ain.test.ts
+++ b/__tests__/ain.test.ts
@@ -9,13 +9,13 @@ const {
   test_keystore,
   test_pw,
   test_seed,
-  test_sk,
   test_node_1,
   test_node_2
 } = require('./test_data');
 
-const TEST_STRING = 'test_string';
 const TX_PATTERN = /^0x([A-Fa-f0-9]{64})$/;
+const TEST_SK = 'ee0b1315d446e5318eb6eb4e9d071cd12ef42d2956d546f9acbdc3b75c469640';
+const TEST_ADDR = '0x09A0d53FDf1c36A131938eb379b98910e55EEfe1';
 
 jest.setTimeout(180000);
 
@@ -97,7 +97,7 @@ describe('ain-js', function() {
 
     it('add', function() {
       let beforeLength = ain.wallet.length;
-      ain.wallet.add(test_sk);
+      ain.wallet.add(TEST_SK);
       let afterLength = ain.wallet.length;
       expect(afterLength).toBe(beforeLength + 1);
 
@@ -112,8 +112,8 @@ describe('ain-js', function() {
     });
 
     it('addAndSetDefaultAccount', function () {
-      ain.wallet.addAndSetDefaultAccount(test_sk);
-      expect(ain.wallet.defaultAccount!.private_key).toBe(test_sk);
+      ain.wallet.addAndSetDefaultAccount(TEST_SK);
+      expect(ain.wallet.defaultAccount!.private_key).toBe(TEST_SK);
     });
 
     it('addFromHDWallet', function() {
@@ -139,15 +139,15 @@ describe('ain-js', function() {
 
     it('setDefaultAccount', function() {
       try {
-        ain.wallet.setDefaultAccount('0x09A0d53FDf1c36A131938eb379b98910e55EEfe1');
+        ain.wallet.setDefaultAccount(TEST_ADDR);
       } catch(e) {
         expect(e.message).toBe('[ain-js.wallet.setDefaultAccount] Add the account first before setting it to defaultAccount.');
       }
-      ain.wallet.add(test_sk);
-      ain.wallet.setDefaultAccount(('0x09A0d53FDf1c36A131938eb379b98910e55EEfe1'.toLowerCase()));
-      expect(ain.wallet.defaultAccount!.address).toBe('0x09A0d53FDf1c36A131938eb379b98910e55EEfe1');
-      ain.wallet.setDefaultAccount('0x09A0d53FDf1c36A131938eb379b98910e55EEfe1');
-      expect(ain.wallet.defaultAccount!.address).toBe('0x09A0d53FDf1c36A131938eb379b98910e55EEfe1');
+      ain.wallet.add(TEST_SK);
+      ain.wallet.setDefaultAccount((TEST_ADDR.toLowerCase()));
+      expect(ain.wallet.defaultAccount!.address).toBe(TEST_ADDR);
+      ain.wallet.setDefaultAccount(TEST_ADDR);
+      expect(ain.wallet.defaultAccount!.address).toBe(TEST_ADDR);
     });
 
     it('removeDefaultAccount', function() {
@@ -163,7 +163,7 @@ describe('ain-js', function() {
       } catch(e) {
         expect(e.message).toBe('You need to specify the address or set defaultAccount.');
       }
-      ain.wallet.setDefaultAccount('0x09A0d53FDf1c36A131938eb379b98910e55EEfe1');
+      ain.wallet.setDefaultAccount(TEST_ADDR);
       const sig = ain.wallet.sign(message);
       const addr:string = String(ain.wallet.defaultAccount!.address);
       expect(Ain.utils.ecVerifySig(message, sig, addr)).toBe(true);

--- a/__tests__/ain.test.ts
+++ b/__tests__/ain.test.ts
@@ -4,6 +4,7 @@ import { TransactionBody, SetOperation, Transaction, TransactionInput, SetOperat
 import { createSecretKey } from 'crypto';
 import { anyTypeAnnotation } from '@babel/types';
 import axios from 'axios';
+import { fail, eraseProtoVer } from './test_util';
 const {
   test_keystore,
   test_pw,
@@ -18,12 +19,7 @@ const TX_PATTERN = /^0x([A-Fa-f0-9]{64})$/;
 
 jest.setTimeout(180000);
 
-function eraseProtoVer(retVal) {
-  retVal.protoVer = 'erased';
-  return retVal;
-}
-
-// TODO (lia): Create more test cases
+// TODO (liayoo): Create more test cases
 describe('ain-js', function() {
   let ain = new Ain(test_node_1);
   let keystoreAddress = '';
@@ -61,7 +57,7 @@ describe('ain-js', function() {
       })
       .catch(e => {
         console.log("ERROR:", e);
-        fail();
+        fail('should not happen');
       })
     });
 
@@ -73,7 +69,7 @@ describe('ain-js', function() {
       })
       .catch(e => {
         console.log("ERROR:", e)
-        fail();
+        fail('should not happen');
       })
     });
   });
@@ -354,7 +350,7 @@ describe('ain-js', function() {
       expect(await ain.getValidators(hash)).toStrictEqual(validators);
     });
 
-    // TODO (lia): add getTransactionResult method and test case for it
+    // TODO (liayoo): add getTransactionResult method and test case for it
     // it('getTransactionResult', async function() {
     //   expect(await ain.getTransactionResult('0xabcdefghijklmnop')).toMatchSnapshot();
     // });
@@ -388,7 +384,7 @@ describe('ain-js', function() {
       })
       .catch(e => {
         console.log("ERROR:", e)
-        fail();
+        fail('should not happen');
       })
     });
 
@@ -424,12 +420,13 @@ describe('ain-js', function() {
 
       await ain.sendSignedTransaction(sig, tx)
       .then(res => {
-        expect(res.result.code).toBe(0);
+        expect(res.code).toBe(undefined);
         expect(res.tx_hash).toEqual(expect.stringMatching(TX_PATTERN));
+        expect(res.result.code).toBe(0);
       })
       .catch(e => {
         console.log("ERROR:", e);
-        fail();
+        fail('should not happen');
       })
     });
 
@@ -569,7 +566,7 @@ describe('ain-js', function() {
       })
       .catch(e => {
         console.log("ERROR:", e);
-        fail();
+        fail('should not happen');
       })
     });
 
@@ -619,7 +616,7 @@ describe('ain-js', function() {
       })
       .catch((error) => {
         console.log("setOwner error:", error);
-        fail();
+        fail('should not happen');
       });
     });
 
@@ -643,7 +640,7 @@ describe('ain-js', function() {
       })
       .catch((error) => {
         console.log("setOwner error:", error);
-        fail();
+        fail('should not happen');
       });
     });
 
@@ -656,7 +653,7 @@ describe('ain-js', function() {
       })
       .catch((error) => {
         console.log("setRule error:", error);
-        fail();
+        fail('should not happen');
       });
     });
 
@@ -669,7 +666,7 @@ describe('ain-js', function() {
       })
       .catch((error) => {
         console.log("setValue error:", error);
-        fail();
+        fail('should not happen');
       });
     });
 
@@ -690,7 +687,7 @@ describe('ain-js', function() {
         })
         .catch((error) => {
           console.log("setFunction error:", error);
-          fail();
+          fail('should not happen');
         })
     });
 
@@ -725,7 +722,7 @@ describe('ain-js', function() {
       })
       .catch((error) => {
         console.log("set error:",error);
-        fail();
+        fail('should not happen');
       });
     });
 
@@ -866,18 +863,78 @@ describe('ain-js', function() {
       })
       .catch((error) => {
         console.log("deleteValue error:",error);
-        fail();
+        fail('should not happen');
       });
     });
 
     it('evalRule: true', async function() {
       await ain.db.ref(allowed_path).evalRule({ ref: '/can/write', value: 'hi' })
       .then(res => {
-        expect(res).toStrictEqual({"code": 0, "matched": {"state": {"closestRule": {"config": null, "path": []}, "matchedRulePath": ["apps", "bfan", "users", "0x09A0d53FDf1c36A131938eb379b98910e55EEfe1", "can", "write"], "matchedValuePath": ["apps", "bfan", "users", "0x09A0d53FDf1c36A131938eb379b98910e55EEfe1", "can", "write"], "pathVars": {}}, "write": {"closestRule": {"config": {"write": "true"}, "path": ["apps", "bfan", "users", "0x09A0d53FDf1c36A131938eb379b98910e55EEfe1", "can", "write"]}, "matchedRulePath": ["apps", "bfan", "users", "0x09A0d53FDf1c36A131938eb379b98910e55EEfe1", "can", "write"], "matchedValuePath": ["apps", "bfan", "users", "0x09A0d53FDf1c36A131938eb379b98910e55EEfe1", "can", "write"], "pathVars": {}, "subtreeRules": []}}});
+        expect(res).toStrictEqual({
+          "code": 0,
+          "matched": {
+            "state": {
+              "closestRule": {
+                "config": null,
+                "path": []
+              },
+              "matchedRulePath": [
+                "apps",
+                "bfan",
+                "users",
+                "0x09A0d53FDf1c36A131938eb379b98910e55EEfe1",
+                "can",
+                "write"
+              ],
+              "matchedValuePath": [
+                "apps",
+                "bfan",
+                "users",
+                "0x09A0d53FDf1c36A131938eb379b98910e55EEfe1",
+                "can",
+                "write"
+              ],
+              "pathVars": {}
+            },
+            "write": {
+              "closestRule": {
+                "config": {
+                  "write": "true"
+                },
+                "path": [
+                  "apps",
+                  "bfan",
+                  "users",
+                  "0x09A0d53FDf1c36A131938eb379b98910e55EEfe1",
+                  "can",
+                  "write"
+                ]
+              },
+              "matchedRulePath": [
+                "apps",
+                "bfan",
+                "users",
+                "0x09A0d53FDf1c36A131938eb379b98910e55EEfe1",
+                "can",
+                "write"
+              ],
+              "matchedValuePath": [
+                "apps",
+                "bfan",
+                "users",
+                "0x09A0d53FDf1c36A131938eb379b98910e55EEfe1",
+                "can",
+                "write"
+              ],
+              "pathVars": {},
+              "subtreeRules": []
+            }
+          }
+        });
       })
       .catch(error => {
         console.log("error:", error);
-        fail();
+        fail('should not happen');
       })
     });
 
@@ -888,7 +945,7 @@ describe('ain-js', function() {
       })
       .catch(error => {
         console.log("error:", error);
-        fail();
+        fail('should not happen');
       })
     });
 
@@ -899,7 +956,7 @@ describe('ain-js', function() {
       })
       .catch(error => {
         console.log("error:", error);
-        fail();
+        fail('should not happen');
       })
     });
 
@@ -910,7 +967,7 @@ describe('ain-js', function() {
       })
       .catch(error => {
         console.log("error:", error);
-        fail();
+        fail('should not happen');
       })
     });
 
@@ -921,7 +978,7 @@ describe('ain-js', function() {
       })
       .catch(error => {
         console.log("error:", error);
-        fail();
+        fail('should not happen');
       })
     });
 
@@ -932,7 +989,7 @@ describe('ain-js', function() {
       })
       .catch(error => {
         console.log("error:", error);
-        fail();
+        fail('should not happen');
       })
     });
 

--- a/__tests__/ain.test.ts
+++ b/__tests__/ain.test.ts
@@ -21,7 +21,7 @@ jest.setTimeout(180000);
 
 // TODO(liayoo): Create more test cases.
 describe('ain-js', function() {
-  let ain = new Ain(test_node_1);
+  const ain = new Ain(test_node_1);
   let keystoreAddress = '';
 
   describe('Network', function() {

--- a/__tests__/ain.test.ts
+++ b/__tests__/ain.test.ts
@@ -19,7 +19,7 @@ const TEST_ADDR = '0x09A0d53FDf1c36A131938eb379b98910e55EEfe1';
 
 jest.setTimeout(180000);
 
-// TODO (liayoo): Create more test cases
+// TODO(liayoo): Create more test cases.
 describe('ain-js', function() {
   let ain = new Ain(test_node_1);
   let keystoreAddress = '';
@@ -350,7 +350,7 @@ describe('ain-js', function() {
       expect(await ain.getValidators(hash)).toStrictEqual(validators);
     });
 
-    // TODO (liayoo): add getTransactionResult method and test case for it
+    // TODO(liayoo): add getTransactionResult method and test case for it.
     // it('getTransactionResult', async function() {
     //   expect(await ain.getTransactionResult('0xabcdefghijklmnop')).toMatchSnapshot();
     // });

--- a/__tests__/ain_raw.test.ts
+++ b/__tests__/ain_raw.test.ts
@@ -3,12 +3,13 @@ import { TransactionBody, SetOperation, TransactionInput } from '../src/types';
 import axios from 'axios';
 import { fail, eraseProtoVer } from './test_util';
 const {
-  test_sk,
   test_node_1,
   test_node_2
 } = require('./test_data');
 
 const TX_PATTERN = /^0x([A-Fa-f0-9]{64})$/;
+const TEST_SK = '9fad756c0bd0d3a42643973f36e61d4d76e01cbb41371fa3046bcced6926e1b2"';
+const TEST_ADDR = '0x08Aed7AF9354435c38d52143EE50ac839D20696b';
 
 jest.setTimeout(180000);
 
@@ -16,16 +17,8 @@ describe('ain-js', function() {
   let ain = new Ain(test_node_1, 0, { isRawResultMode: true });
 
   beforeAll(() => {
-    try {
-      ain.wallet.setDefaultAccount('0x09A0d53FDf1c36A131938eb379b98910e55EEfe1');
-    } catch(e) {
-      expect(e.message).toBe('[ain-js.wallet.setDefaultAccount] Add the account first before setting it to defaultAccount.');
-    }
-    ain.wallet.add(test_sk);
-    ain.wallet.setDefaultAccount(('0x09A0d53FDf1c36A131938eb379b98910e55EEfe1'.toLowerCase()));
-    expect(ain.wallet.defaultAccount!.address).toBe('0x09A0d53FDf1c36A131938eb379b98910e55EEfe1');
-    ain.wallet.setDefaultAccount('0x09A0d53FDf1c36A131938eb379b98910e55EEfe1');
-    expect(ain.wallet.defaultAccount!.address).toBe('0x09A0d53FDf1c36A131938eb379b98910e55EEfe1');
+    ain.wallet.add(TEST_SK);
+    ain.wallet.setDefaultAccount(TEST_ADDR);
   });
 
   describe('Core', function() {
@@ -361,7 +354,7 @@ describe('ain-js', function() {
         "result": [
           {
             ".rule": {
-              "write": "auth.addr === \"0x09A0d53FDf1c36A131938eb379b98910e55EEfe1\"",
+              "write": "auth.addr === \"0x08Aed7AF9354435c38d52143EE50ac839D20696b\"",
             },
           },
           false,

--- a/__tests__/ain_raw.test.ts
+++ b/__tests__/ain_raw.test.ts
@@ -1,6 +1,7 @@
 import Ain from '../src/ain';
 import { TransactionBody, SetOperation, TransactionInput } from '../src/types';
 import axios from 'axios';
+import { fail, eraseProtoVer } from './test_util';
 const {
   test_sk,
   test_node_1,
@@ -11,14 +12,8 @@ const TX_PATTERN = /^0x([A-Fa-f0-9]{64})$/;
 
 jest.setTimeout(180000);
 
-function eraseProtoVer(retVal) {
-  retVal.protoVer = 'erased';
-  return retVal;
-}
-
 describe('ain-js', function() {
-  let ain = new Ain(test_node_1);
-  ain.setRawResultMode(true);
+  let ain = new Ain(test_node_1, 0, { isRawResultMode: true });
 
   beforeAll(() => {
     try {
@@ -158,36 +153,13 @@ describe('ain-js', function() {
 
       await ain.sendSignedTransaction(sig, tx)
       .then(res => {
-        expect(eraseProtoVer(res)).toStrictEqual({
-          "protoVer": "erased",
-          "result": {
-            "result": {
-              "bandwidth_gas_amount": 1,
-              "code": 0,
-              "gas_amount_charged": 0,
-              "gas_amount_total": {
-                "bandwidth": {
-                  "app": {
-                    "bfan_raw": 1,
-                  },
-                  "service": 0,
-                },
-                "state": {
-                  "app": {
-                    "bfan_raw": 912,
-                  },
-                  "service": 0,
-                },
-              },
-              "gas_cost_total": 0,
-            },
-            "tx_hash": "0xdf776dd3771f6b9a55f5183f2d2015417d7860bea3719fc1286a4e08520da271",
-          },
-        });
+        expect(res.code).toBe(undefined);
+        expect(res.result.tx_hash).toEqual(expect.stringMatching(TX_PATTERN));
+        expect(res.result.result.code).toBe(0);
       })
       .catch(e => {
         console.log("ERROR:", e)
-        fail();
+        fail('should not happen');
       })
     });
 
@@ -226,7 +198,7 @@ describe('ain-js', function() {
       })
       .catch(e => {
         console.log("ERROR:", e)
-        fail();
+        fail('should not happen');
       })
     });
 
@@ -332,7 +304,7 @@ describe('ain-js', function() {
       })
       .catch(e => {
         console.log("ERROR:", e)
-        fail();
+        fail('should not happen');
       })
     });
 
@@ -348,7 +320,7 @@ describe('ain-js', function() {
       })
       .catch(e => {
         console.log("ERROR:", e)
-        fail();
+        fail('should not happen');
       })
     });
   });

--- a/__tests__/ain_raw.test.ts
+++ b/__tests__/ain_raw.test.ts
@@ -1,0 +1,411 @@
+import Ain from '../src/ain';
+import { TransactionBody, SetOperation, TransactionInput } from '../src/types';
+import axios from 'axios';
+const {
+  test_sk,
+  test_node_1,
+  test_node_2
+} = require('./test_data');
+
+const TX_PATTERN = /^0x([A-Fa-f0-9]{64})$/;
+
+jest.setTimeout(180000);
+
+function eraseProtoVer(retVal) {
+  retVal.protoVer = 'erased';
+  return retVal;
+}
+
+describe('ain-js', function() {
+  let ain = new Ain(test_node_1);
+  ain.setRawResultMode(true);
+
+  beforeAll(() => {
+    try {
+      ain.wallet.setDefaultAccount('0x09A0d53FDf1c36A131938eb379b98910e55EEfe1');
+    } catch(e) {
+      expect(e.message).toBe('[ain-js.wallet.setDefaultAccount] Add the account first before setting it to defaultAccount.');
+    }
+    ain.wallet.add(test_sk);
+    ain.wallet.setDefaultAccount(('0x09A0d53FDf1c36A131938eb379b98910e55EEfe1'.toLowerCase()));
+    expect(ain.wallet.defaultAccount!.address).toBe('0x09A0d53FDf1c36A131938eb379b98910e55EEfe1');
+    ain.wallet.setDefaultAccount('0x09A0d53FDf1c36A131938eb379b98910e55EEfe1');
+    expect(ain.wallet.defaultAccount!.address).toBe('0x09A0d53FDf1c36A131938eb379b98910e55EEfe1');
+  });
+
+  describe('Core', function() {
+    let addr1: string, addr2: string, defaultAddr: string, targetTxHash: string;
+    const targetTx: SetOperation = {
+      type: 'SET_OWNER',
+      ref: `/apps/test_raw`,
+      value: {
+        ".owner": {
+          "owners": {
+            "*": {
+              write_owner: true,
+              write_rule: true,
+              branch_owner: true,
+              write_function: true,
+            }
+          }
+        }
+      }
+    };
+
+    async function waitUntilTxFinalized(txHash: string) {
+      const MAX_ITERATION = 20;
+      let iterCount = 0;
+      while (true) {
+        if (iterCount >= MAX_ITERATION) {
+          console.log(`Iteration count exceeded its limit before the given tx ${txHash} is finalized!`);
+          return false;
+        }
+        const txStatus = (await axios.get(`${test_node_2}/get_transaction?hash=${txHash}`)).data.result;
+        if (txStatus && txStatus.is_finalized === true) {
+          return true;
+        }
+        await new Promise((resolve) => {
+          setTimeout(resolve, 5000);
+        });
+        iterCount++;
+      }
+    }
+
+    beforeAll(async () => {
+      ain.setProvider(test_node_2, 0);
+      const newAccounts = ain.wallet.create(2);
+      defaultAddr = ain.wallet.defaultAccount!.address as string;
+      addr1 = newAccounts[0];
+      addr2 = newAccounts[1];
+      const nodeAddr = (await axios.get(`${test_node_2}/get_address`)).data.result;
+      const stakeForApps = (await axios.post(`${test_node_2}/set`, {
+        op_list: [
+          {
+            type: 'SET_VALUE',
+            ref: `/staking/test_raw/${nodeAddr}/0/stake/${Date.now()}/value`,
+            value: 1
+          },
+          {
+            type: 'SET_VALUE',
+            ref: `/staking/bfan_raw/${nodeAddr}/0/stake/${Date.now()}/value`,
+            value: 1
+          },
+        ],
+        nonce: -1
+      })).data;
+      await waitUntilTxFinalized(stakeForApps.result.tx_hash);
+
+      const createApps = (await axios.post(`${test_node_2}/set`, {
+        op_list: [
+          {
+            type: 'SET_VALUE',
+            ref: `/manage_app/test_raw/create/${Date.now()}`,
+            value: { admin: { [defaultAddr]: true } }
+          },
+          {
+            type: 'SET_VALUE',
+            ref: `/manage_app/bfan_raw/create/${Date.now()}`,
+            value: { admin: { [defaultAddr]: true } }
+          },
+        ],
+        nonce: -1
+      })).data;
+      await waitUntilTxFinalized(createApps.result.tx_hash);
+    });
+
+    it('validateAppName returns true', async function () {
+      expect(eraseProtoVer(await ain.validateAppName('test_new'))).toStrictEqual({
+        "is_valid": true,
+        "result": true,
+        "code": 0,
+        "protoVer": "erased",
+      });
+    });
+
+    it('validateAppName returns false', async function () {
+      expect(eraseProtoVer(await ain.validateAppName('app/path'))).toStrictEqual({
+        "is_valid": false,
+        "result": false,
+        "code": 30601,
+        "message": "Invalid app name for state label: app/path",
+        "protoVer": "erased",
+      });
+    });
+
+    it('sendSignedTransaction', async function() {
+      const tx: TransactionBody = {
+        nonce: -1,
+        gas_price: 500,
+        timestamp: Date.now(),
+        operation: {
+          type: "SET_OWNER",
+          ref: "/apps/bfan_raw",
+          value: {
+            ".owner": {
+              "owners": {
+                "*": {
+                  write_owner: true,
+                  write_rule: true,
+                  branch_owner: true,
+                  write_function: true,
+                }
+              }
+            }
+          }
+        }
+      }
+      const sig = ain.wallet.signTransaction(tx);
+
+      await ain.sendSignedTransaction(sig, tx)
+      .then(res => {
+        expect(eraseProtoVer(res)).toStrictEqual({
+          "protoVer": "erased",
+          "result": {
+            "result": {
+              "bandwidth_gas_amount": 1,
+              "code": 0,
+              "gas_amount_charged": 0,
+              "gas_amount_total": {
+                "bandwidth": {
+                  "app": {
+                    "bfan_raw": 1,
+                  },
+                  "service": 0,
+                },
+                "state": {
+                  "app": {
+                    "bfan_raw": 912,
+                  },
+                  "service": 0,
+                },
+              },
+              "gas_cost_total": 0,
+            },
+            "tx_hash": "0xdf776dd3771f6b9a55f5183f2d2015417d7860bea3719fc1286a4e08520da271",
+          },
+        });
+      })
+      .catch(e => {
+        console.log("ERROR:", e)
+        fail();
+      })
+    });
+
+    it('sendSignedTransaction with invalid signature', async function() {
+      const tx: TransactionBody = {
+        nonce: -1,
+        gas_price: 500,
+        timestamp: Date.now(),
+        operation: {
+          type: "SET_OWNER",
+          ref: "/apps/bfan_raw",
+          value: {
+            ".owner": {
+              "owners": {
+                "*": {
+                  write_owner: true,
+                  write_rule: true,
+                  branch_owner: true,
+                  write_function: true,
+                }
+              }
+            }
+          }
+        }
+      }
+      const sig = '';  // Invalid signature value
+
+      await ain.sendSignedTransaction(sig, tx)
+      .then(res => {
+        expect(eraseProtoVer(res)).toStrictEqual({
+          "code": 30302,
+          "message": "Missing properties.",
+          "protoVer": "erased",
+          "result": null,
+        });
+      })
+      .catch(e => {
+        console.log("ERROR:", e)
+        fail();
+      })
+    });
+
+    it('sendTransactionBatch', async function() {
+      const tx1: TransactionInput = {
+        operation: {
+          type: 'SET_VALUE',
+          ref: "/apps/bfan_raw/users",
+          value: { [defaultAddr]: true }
+        },
+        address: addr1
+      };
+
+      const tx2: TransactionInput = {
+        operation: {
+          type: 'SET',
+          op_list: [
+            {
+              type: 'SET_OWNER',
+              ref: `/apps/bfan_raw/users`,
+              value: {
+                ".owner": {
+                  "owners": {
+                    "*": {
+                      write_owner: false,
+                      write_rule: false,
+                      branch_owner: true,
+                      write_function: true,
+                    }
+                  }
+                }
+              }
+            },
+            {
+              type: 'SET_OWNER',
+              ref: `/apps/bfan_raw/users/${defaultAddr}`,
+              value: {
+                ".owner": {
+                  "owners": {
+                    [defaultAddr]: {
+                      write_owner: true,
+                      write_rule: true,
+                      branch_owner: true,
+                      write_function: true,
+                    }
+                  }
+                }
+              }
+            }
+          ]
+        },
+        address: addr2
+      };
+
+      const tx3: TransactionInput = {
+        operation: {
+          type: 'SET_RULE',
+          ref: `/apps/bfan_raw/users/${defaultAddr}`,
+          value: { '.rule': { 'write': `auth.addr === "${defaultAddr}"` } }
+        }
+      };
+
+      const tx4: TransactionInput = {
+        operation: {
+          type: 'SET_VALUE',
+          ref: `/apps/bfan_raw/users/${defaultAddr}`,
+          value: false
+        }
+      };
+
+      const tx5: TransactionInput = {
+        operation: {
+          type: 'SET_VALUE',
+          ref: `/apps/bfan_raw/users/${defaultAddr}`,
+          value: true
+        },
+        address: addr1
+      };
+
+      const tx6: TransactionInput = {
+        operation: {
+          type: 'SET_RULE',
+          ref: `/apps/bfan_raw/users/${defaultAddr}`,
+          value: { '.rule': { 'write': 'true' } }
+        },
+        address: addr2
+      }
+
+      await ain.sendTransactionBatch([ tx1, tx2, tx3, tx4, tx5, tx6 ])
+      .then(res => {
+        expect(res.result[0].result.code).toBe(12103);
+        expect(res.result[0].tx_hash).toEqual(expect.stringMatching(TX_PATTERN));
+        expect(res.result[1].result.result_list[0].code).toBe(0);
+        expect(res.result[1].tx_hash).toEqual(expect.stringMatching(TX_PATTERN));
+        expect(res.result[2].result.code).toBe(0);
+        expect(res.result[2].tx_hash).toEqual(expect.stringMatching(TX_PATTERN));
+        expect(res.result[3].result.code).toBe(0);
+        expect(res.result[3].tx_hash).toEqual(expect.stringMatching(TX_PATTERN));
+        expect(res.result[4].result.code).toBe(12103);
+        expect(res.result[4].tx_hash).toEqual(expect.stringMatching(TX_PATTERN));
+        expect(res.result[5].result.code).toBe(12302);
+        expect(res.result[5].tx_hash).toEqual(expect.stringMatching(TX_PATTERN));
+      })
+      .catch(e => {
+        console.log("ERROR:", e)
+        fail();
+      })
+    });
+
+    it('sendTransactionBatch with empty tx_list', async function() {
+      await ain.sendTransactionBatch([])
+      .then(res => {
+        expect(eraseProtoVer(res)).toStrictEqual({
+          "result": null,
+          "code": 30401,
+          "message": "Invalid batch transaction format.",
+          "protoVer": "erased",
+        });
+      })
+      .catch(e => {
+        console.log("ERROR:", e)
+        fail();
+      })
+    });
+  });
+
+  describe('Database', function() {
+    let defaultAccount, allowed_path;
+    const test_path = 'apps/bfan_raw';
+
+    beforeAll(() => {
+      defaultAccount = ain.wallet.defaultAccount!.address;
+      allowed_path = `${test_path}/users/${defaultAccount}`;
+    });
+
+    it('getValue', async function() {
+      expect(eraseProtoVer(await ain.db.ref(allowed_path).getValue())).toEqual({
+        "protoVer": "erased",
+        "result": false,
+      });
+    });
+
+    it('get', async function() {
+      expect(eraseProtoVer(await ain.db.ref(allowed_path).get(
+        [
+          {
+            type: 'GET_RULE',
+            ref: ''
+          },
+          {
+            type: 'GET_VALUE',
+          },
+          {
+            type: 'GET_VALUE',
+            ref: 'deeper/path/'
+          }
+        ]
+      ))).toEqual({
+        "protoVer": "erased",
+        "result": [
+          {
+            ".rule": {
+              "write": "auth.addr === \"0x09A0d53FDf1c36A131938eb379b98910e55EEfe1\"",
+            },
+          },
+          false,
+          null,
+        ],
+      });
+    });
+
+    it('get with empty op_list', async function() {
+      expect(await ain.db.ref(allowed_path).get([]))
+      .toEqual({
+        "result": null,
+        "code": 30006,
+        "message": "Invalid op_list given",
+        "protoVer": "1.0.7",
+      });
+    });
+  });
+});

--- a/__tests__/ain_raw.test.ts
+++ b/__tests__/ain_raw.test.ts
@@ -14,7 +14,7 @@ const TEST_ADDR = '0x08Aed7AF9354435c38d52143EE50ac839D20696b';
 jest.setTimeout(180000);
 
 describe('ain-js', function() {
-  let ain = new Ain(test_node_1, 0, { rawResultMode: true });
+  const ain = new Ain(test_node_1, 0, { rawResultMode: true });
 
   beforeAll(() => {
     ain.wallet.add(TEST_SK);

--- a/__tests__/ain_raw.test.ts
+++ b/__tests__/ain_raw.test.ts
@@ -14,7 +14,7 @@ const TEST_ADDR = '0x08Aed7AF9354435c38d52143EE50ac839D20696b';
 jest.setTimeout(180000);
 
 describe('ain-js', function() {
-  let ain = new Ain(test_node_1, 0, { isRawResultMode: true });
+  let ain = new Ain(test_node_1, 0, { rawResultMode: true });
 
   beforeAll(() => {
     ain.wallet.add(TEST_SK);

--- a/__tests__/test_data.ts
+++ b/__tests__/test_data.ts
@@ -1,7 +1,6 @@
 export const test_keystore  = '{"version":3,"id":"253e91a5-3246-4330-b7be-ea1a77b179e1","address":"09a0d53fdf1c36a131938eb379b98910e55eefe1","crypto":{"ciphertext":"6c04b55a8562b60575f1619e83cdffa44d6a642c15e4f21491a3e413f806bb41","cipherparams":{"iv":"2c1637d89bf674c8b87e54120b7f9af3"},"cipher":"aes-128-ctr","kdf":"scrypt","kdfparams":{"dklen":32,"salt":"5ef6abd39bbeae66472ae77629ad17ffa0c0647dcc84837495cccc4efddc495d","n":262144,"r":8,"p":1},"mac":"9bd0e43d4db4871a882b8376094aabdf041328c307b4549f18f0d2f55dcb2d42"}}';
 export const test_pw = 'ainetwork';
 export const test_seed = 'receive ocean impact unaware march just dragon easy power muscle together flip';
-export const test_sk = 'ee0b1315d446e5318eb6eb4e9d071cd12ef42d2956d546f9acbdc3b75c469640';
 
 export const test_node_1 = 'http://localhost:8081';
 export const test_node_2 = 'http://localhost:8081';

--- a/__tests__/test_util.ts
+++ b/__tests__/test_util.ts
@@ -1,0 +1,6 @@
+export declare function fail(error?: any): never;
+
+export function eraseProtoVer(retVal) {
+  retVal.protoVer = 'erased';
+  return retVal;
+}

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test_snapshot": "jest --updateSnapshot",
     "test_ain": "jest ain.test.ts",
     "test_ain_snapshot": "jest ain.test.ts --updateSnapshot",
+    "test_ain_raw": "jest ain_raw.test.ts",
     "test_he": "jest he.test.ts",
     "test_em": "jest event_manager.test.ts"
   },

--- a/src/ain-db/ref.ts
+++ b/src/ain-db/ref.ts
@@ -310,7 +310,7 @@ export default class Reference {
   }
 
   /**
-   * TODO (lia): Add this function
+   * TODO(liayoo): Add this function.
    * Attaches an listener for database events.
    * @param {EventType} event - A type of event.
    * @param {Function} callback function to be executed when an event occurs.
@@ -335,7 +335,7 @@ export default class Reference {
   // }
 
   /**
-   * TODO (lia): Add this function
+   * TODO (liayoo): Add this function
    * Removes a database event listener.
    * @param {EventType} event - A type of event.
    * @param {Function} callback - A callback function to dettach from the event.

--- a/src/ain.ts
+++ b/src/ain.ts
@@ -16,6 +16,7 @@ import HomomorphicEncryption from './he';
 export default class Ain {
   public chainId: number;
   public provider: Provider;
+  public isRawResultMode: boolean;
   public db: Database;
   public net: Network;
   public wallet: Wallet;
@@ -28,12 +29,21 @@ export default class Ain {
    */
   constructor(providerUrl: string, chainId?: number) {
     this.provider = new Provider(this, providerUrl);
+    this.isRawResultMode = false;
     this.chainId = chainId || 0;
     this.net = new Network(this.provider);
     this.wallet = new Wallet(this, this.chainId);
     this.db = new Database(this, this.provider);
     this.he = new HomomorphicEncryption();
     this.em = new EventManager(this);
+  }
+
+  /**
+   * Sets this.isRawResultMode.
+   * @param {boolean} mode
+   */
+  setRawResultMode(mode: boolean) {
+    this.isRawResultMode = mode;
   }
 
   /**

--- a/src/ain.ts
+++ b/src/ain.ts
@@ -2,8 +2,8 @@ import * as EventEmitter from 'eventemitter3'
 import * as AinUtil from "@ainblockchain/ain-util";
 import request from './request';
 import {
-  Block, TransactionInfo, TransactionBody, TransactionResult, SetOperationType,
-  SetOperation, TransactionInput, ValueOnlyTransactionInput, StateUsageInfo, AppNameValidationInfo
+  AinOptions, Block, TransactionInfo, TransactionBody, TransactionResult, SetOperationType,
+  SetOperation, TransactionInput, ValueOnlyTransactionInput, StateUsageInfo, AppNameValidationInfo,
 } from './types';
 import Provider from './provider';
 import Database from './ain-db/db';
@@ -27,23 +27,15 @@ export default class Ain {
    * @param {string} providerUrl
    * @constructor
    */
-  constructor(providerUrl: string, chainId?: number) {
+  constructor(providerUrl: string, chainId?: number, ainOptions?: AinOptions) {
     this.provider = new Provider(this, providerUrl);
-    this.isRawResultMode = false;
+    this.isRawResultMode = ainOptions ? !!ainOptions.isRawResultMode : false;
     this.chainId = chainId || 0;
     this.net = new Network(this.provider);
     this.wallet = new Wallet(this, this.chainId);
     this.db = new Database(this, this.provider);
     this.he = new HomomorphicEncryption();
     this.em = new EventManager(this);
-  }
-
-  /**
-   * Sets this.isRawResultMode.
-   * @param {boolean} mode
-   */
-  setRawResultMode(mode: boolean) {
-    this.isRawResultMode = mode;
   }
 
   /**

--- a/src/ain.ts
+++ b/src/ain.ts
@@ -113,7 +113,7 @@ export default class Ain {
    * @param {string} transactionHash
    * @return {Promise<Transaction>}
    */
-  // TODO (lia): implement this function
+  // TODO(liayoo): implement this function.
   // getTransactionResult(transactionHash: string): Promise<TransactionResult> {}
 
   /**

--- a/src/ain.ts
+++ b/src/ain.ts
@@ -29,8 +29,8 @@ export default class Ain {
    */
   constructor(providerUrl: string, chainId?: number, ainOptions?: AinOptions) {
     this.provider = new Provider(this, providerUrl);
-    this.rawResultMode = ainOptions ? !!ainOptions.rawResultMode : false;
     this.chainId = chainId || 0;
+    this.rawResultMode = ainOptions?.rawResultMode || false;
     this.net = new Network(this.provider);
     this.wallet = new Wallet(this, this.chainId);
     this.db = new Database(this, this.provider);

--- a/src/ain.ts
+++ b/src/ain.ts
@@ -16,7 +16,7 @@ import HomomorphicEncryption from './he';
 export default class Ain {
   public chainId: number;
   public provider: Provider;
-  public isRawResultMode: boolean;
+  public rawResultMode: boolean;
   public db: Database;
   public net: Network;
   public wallet: Wallet;
@@ -29,7 +29,7 @@ export default class Ain {
    */
   constructor(providerUrl: string, chainId?: number, ainOptions?: AinOptions) {
     this.provider = new Provider(this, providerUrl);
-    this.isRawResultMode = ainOptions ? !!ainOptions.isRawResultMode : false;
+    this.rawResultMode = ainOptions ? !!ainOptions.rawResultMode : false;
     this.chainId = chainId || 0;
     this.net = new Network(this.provider);
     this.wallet = new Wallet(this, this.chainId);

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -43,7 +43,7 @@ export default class Provider {
     };
     const response = await this.httpClient.post(this.apiEndpoint, data);
     const rawResult = get(response, 'data.result');
-    if (this.ain.isRawResultMode) {
+    if (this.ain.rawResultMode) {
       return rawResult;
     }
     if (typeof rawResult !== 'object' || !(rawResult.code === undefined || rawResult.code === 0)) {

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -43,6 +43,9 @@ export default class Provider {
     };
     const response = await this.httpClient.post(this.apiEndpoint, data);
     const rawResult = get(response, 'data.result');
+    if (this.ain.isRawResultMode) {
+      return rawResult;
+    }
     if (typeof rawResult !== 'object' || !(rawResult.code === undefined || rawResult.code === 0)) {
       throw new BlockchainError(rawResult.code, rawResult.message);
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -47,7 +47,7 @@ export interface V3Keystore {
 }
 
 export type AinOptions = {
-  isRawResultMode?: boolean;
+  rawResultMode?: boolean;
 }
 
 // export type EventType = "value" | "child_added" | "child_changed" | "child_removed";

--- a/src/types.ts
+++ b/src/types.ts
@@ -46,6 +46,10 @@ export interface V3Keystore {
   };
 }
 
+export type AinOptions = {
+  isRawResultMode?: boolean;
+}
+
 // export type EventType = "value" | "child_added" | "child_changed" | "child_removed";
 
 export type SetMultiOperationType = "SET";

--- a/src/wallet.ts
+++ b/src/wallet.ts
@@ -57,7 +57,7 @@ export default class Wallet {
    */
   create(numberOfAccounts: number): Array<string> {
     if (numberOfAccounts <= 0) throw Error("numberOfAccounts should be greater than 0.");
-    // TODO (lia): set maximum limit for numberOfAccounts?
+    // TODO(liayoo): set maximum limit for numberOfAccounts?
     let newAccounts: Array<string> = [];
     for (let i = 0; i < numberOfAccounts; i++) {
       let account = Ain.utils.createAccount();


### PR DESCRIPTION
Change summary:
- Support rawResultMode = true option in Ain class
- Refactor some test code 

Background:
- If rawResultMode = true, blockchain access APIs always return raw results without BlockchainError throwing 

Related issues:
- https://github.com/ainblockchain/ain-blockchain/issues/1053