### PR TITLE
Fix/ehgmsdk20/improve test code

### DIFF
--- a/__tests__/event_manager.test.ts
+++ b/__tests__/event_manager.test.ts
@@ -7,7 +7,7 @@ const delayMs = (time) => new Promise(resolve => setTimeout(resolve, time));
 jest.setTimeout(180000);
 
 describe('Event Handler', function() {
-  let ain = new Ain('https://testnet-event.ainetwork.ai/');
+  let ain = new Ain(test_event_handler_node);
   let eventFilterId: string;
 
   beforeAll(async () => {

--- a/__tests__/event_manager.test.ts
+++ b/__tests__/event_manager.test.ts
@@ -7,11 +7,20 @@ const delayMs = (time) => new Promise(resolve => setTimeout(resolve, time));
 jest.setTimeout(180000);
 
 describe('Event Handler', function() {
-  let ain = new Ain(test_event_handler_node);
+  let ain = new Ain('https://testnet-event.ainetwork.ai/');
+  let eventFilterId: string;
 
   beforeAll(async () => {
     await ain.em.connect();
   });
+
+  afterEach(async () => {
+    ain.em.unsubscribe(eventFilterId, (err) => {
+      if (err) {
+        console.log(`Failed to unsubscribe subscription. (${err.message})`);
+      }
+    });
+  })
 
   afterAll(() => {
     ain.em.disconnect();
@@ -19,7 +28,7 @@ describe('Event Handler', function() {
 
   describe('BLOCK_FINALIZED', () => {
     it('Subscribe to BLOCK_FINALIZED', (done) => {
-      ain.em.subscribe('BLOCK_FINALIZED', {
+      eventFilterId = ain.em.subscribe('BLOCK_FINALIZED', {
         block_number: null,
       }, (data) => {
         done();
@@ -27,7 +36,7 @@ describe('Event Handler', function() {
     });
 
     it('Subscribe to BLOCK_FINALIZED with wrong config', (done) => {
-      ain.em.subscribe('BLOCK_FINALIZED', {
+      eventFilterId = ain.em.subscribe('BLOCK_FINALIZED', {
         block_number: -1,
       }, (data) => {
       }, (err) => {
@@ -53,7 +62,7 @@ describe('Event Handler', function() {
       let blockEventCount = 0;
       let userEventCount = 0;
 
-      ain.em.subscribe('VALUE_CHANGED', {
+      eventFilterId = ain.em.subscribe('VALUE_CHANGED', {
         path: testAppPath,
         event_source: null,
       }, (event) => {
@@ -65,10 +74,14 @@ describe('Event Handler', function() {
             userEventCount++;
             break;
         }
-        if (blockEventCount + userEventCount === 2) {
-          expect(blockEventCount).toBe(1);
-          expect(userEventCount).toBe(1);
-          done();
+        try {
+          if (blockEventCount + userEventCount === 2) {
+            expect(blockEventCount).toBe(1);
+            expect(userEventCount).toBe(1);
+            done();
+          }
+        } catch (err) {
+          done(err);
         }
       });
 
@@ -78,12 +91,16 @@ describe('Event Handler', function() {
     });
 
     it('Subscribe to VALUE_CHANGED with event_source = BLOCK', (done) => {
-      ain.em.subscribe('VALUE_CHANGED', {
+      eventFilterId = ain.em.subscribe('VALUE_CHANGED', {
         path: testAppPath,
         event_source: 'BLOCK',
       }, (event) => {
-        expect(event.event_source).toBe('BLOCK');
-        done();
+        try {
+          expect(event.event_source).toBe('BLOCK');
+          done();
+        } catch (err) {
+          done(err);
+        }
       });
 
       ain.db.ref(testAppPath).setValue({
@@ -92,12 +109,16 @@ describe('Event Handler', function() {
     });
 
     it('Subscribe to VALUE_CHANGED with event_source = USER', (done) => {
-      ain.em.subscribe('VALUE_CHANGED', {
+      eventFilterId = ain.em.subscribe('VALUE_CHANGED', {
         path: testAppPath,
         event_source: 'USER',
       }, (event) => {
-        expect(event.event_source).toBe('USER');
-        done();
+        try {
+          expect(event.event_source).toBe('USER');
+          done();
+        } catch (err) {
+          done(err);
+        }
       });
 
       ain.db.ref(testAppPath).setValue({
@@ -106,7 +127,7 @@ describe('Event Handler', function() {
     });
 
     it('Subscribe to VALUE_CHANGED with wrong config', (done) => {
-      ain.em.subscribe('VALUE_CHANGED', {
+      eventFilterId = ain.em.subscribe('VALUE_CHANGED', {
         path: '/..wrong_app_name',
         event_source: null,
       }, (event) => {
@@ -135,79 +156,92 @@ describe('Event Handler', function() {
         ain.db.ref(testAppPath).setValue({
           value: Date.now(),
         }).then((result)=>{
-          const filterId = ain.em.subscribe('TX_STATE_CHANGED', {
+          eventFilterId = ain.em.subscribe('TX_STATE_CHANGED', {
             tx_hash: result.tx_hash,
           }, (event) => {
-            if (eventTriggeredCnt === 0) {
-              expect(event.tx_state.before).toBe(null);
-              expect(event.tx_state.after).toBe(TransactionStates.EXECUTED);
-              eventTriggeredCnt++;
-            } else {
-              expect(event.tx_state.before).toBe(TransactionStates.EXECUTED);
-              expect(event.tx_state.after).toBe(TransactionStates.FINALIZED);
-              eventTriggeredCnt++;
+            try {
+              if (eventTriggeredCnt === 0) {
+                expect(event.tx_state.before).toBe(null);
+                expect(event.tx_state.after).toBe(TransactionStates.EXECUTED);
+                eventTriggeredCnt++;
+              } else {
+                expect(event.tx_state.before).toBe(TransactionStates.EXECUTED);
+                expect(event.tx_state.after).toBe(TransactionStates.FINALIZED);
+                eventTriggeredCnt++;
+              }
+            } catch (err) {
+              done(err);
             }
           }, (err) => {
-            done.fail(new Error(err.message));
+            done(new Error(err.message));
           }, (event) => {
-            expect(eventTriggeredCnt).toBe(2);
-            expect(event.filter_id).toBe(filterId);
-            expect(event.reason).toBe(FilterDeletionReasons.END_STATE_REACHED);
-            done();
-          })
+            try {
+              expect(eventTriggeredCnt).toBe(2);
+              expect(event.filter_id).toBe(eventFilterId);
+              expect(event.reason).toBe(FilterDeletionReasons.END_STATE_REACHED);
+              done();
+            } catch (err) {
+              done(err);
+            }
+          });
         })
       });
       it('Invalid transaction', (done) => {
-        let eventTriggeredCnt = 0;
         ain.db.ref('/apps/invalid').setValue({
           value: Date.now(),
         }).then((result)=>{
-          const filterId = ain.em.subscribe('TX_STATE_CHANGED', {
+          eventFilterId = ain.em.subscribe('TX_STATE_CHANGED', {
             tx_hash: result.tx_hash,
           }, (event) => {
-            if (eventTriggeredCnt === 0) {
+            try {
+              // NOTE(ehgmsdk20): It only checks if the transaction has been added to the tx_pool
+              // in a PENDING state, but does not check the tx state change after that.
+              // If the node that executed the Tx does not become a proposal node,
+              // the state of the sent tx will change from PENDING to TIMED_OUT,
+              // which takes too long for the test to wait.
               expect(event.tx_state.before).toBe(null);
               expect(event.tx_state.after).toBe(TransactionStates.PENDING);
-              eventTriggeredCnt++;
-            } else {
-              expect(event.tx_state.before).toBe(TransactionStates.PENDING);
-              expect(event.tx_state.after).toBe(TransactionStates.REVERTED);
-              eventTriggeredCnt++;
+              done();
+            } catch (err) {
+              done(err);
             }
           }, (err) => {
-            done.fail(new Error(err.message));
-          }, (event) => {
-            expect(eventTriggeredCnt).toBe(2);
-            expect(event.filter_id).toBe(filterId);
-            expect(event.reason).toBe(FilterDeletionReasons.END_STATE_REACHED);
-            done();
+            done(new Error(err.message));
           })
-        })
+        });
       });
     });
 
     it('Subscribe to TX_STATE_CHANGED and deleted because of timeout', (done) => {
-      const filterId = ain.em.subscribe('TX_STATE_CHANGED', {
+      eventFilterId = ain.em.subscribe('TX_STATE_CHANGED', {
         tx_hash: '0x9ac44b45853c2244715528f89072a337540c909c36bab4c9ed2fd7b7dbab47b2',
       }, (event) => {
-        done.fail(new Error('Tx must not be executed'));
+        done(new Error('Tx must not be executed'));
       }, (err) => {
-        done.fail(new Error(err.message));
+        done(new Error(err.message));
       }, (event) => {
-        expect(event.filter_id).toBe(filterId);
-        expect(event.reason).toBe(FilterDeletionReasons.FILTER_TIMEOUT);
-        done();
+        try {
+          expect(event.filter_id).toBe(eventFilterId);
+          expect(event.reason).toBe(FilterDeletionReasons.FILTER_TIMEOUT);
+          done();
+        } catch (err) {
+          done(err);
+        }
       });
     });
 
     it('Subscribe to TX_STATE_CHANGED with wrong config', (done) => {
-      ain.em.subscribe('TX_STATE_CHANGED', {
+      eventFilterId = ain.em.subscribe('TX_STATE_CHANGED', {
         tx_hash: '123',
       }, (event) => {
       }, (err) => {
-        expect(err.code).toBe(70301);
-        expect(err.message).toBe('Invalid tx hash (123)');
-        done();
+        try {
+          expect(err.code).toBe(70301);
+          expect(err.message).toBe('Invalid tx hash (123)');
+          done();
+        } catch (err) {
+          done(err);
+        }
       });
     });
   });

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   ],
   "devDependencies": {
     "@types/jest": "^27.0.2",
+    "@types/ws": "^8.5.3",
     "jest": "^27.3.1",
     "ts-jest": "^27.0.7",
     "typescript": "^3.9.10"

--- a/src/event-manager/event-channel-client.ts
+++ b/src/event-manager/event-channel-client.ts
@@ -66,7 +66,7 @@ export default class EventChannelClient {
 
       this._endpointUrl = url;
       this._wsClient = new WebSocket(url, [], { handshakeTimeout: connectionOption.handshakeTimeout || DEFAULT_HANDSHAKE_TIMEOUT_MS });
-      this._wsClient.on('message', (message) => {
+      this._wsClient.on('message', (message: string) => {
         this.handleMessage(message);
       });
       this._wsClient.on('error', (err) => {
@@ -76,7 +76,7 @@ export default class EventChannelClient {
       this._wsClient.on('open', () => {
         this._isConnected = true;
         this.startHeartbeatTimer(connectionOption.heartbeatIntervalMs || DEFAULT_HEARTBEAT_INTERVAL_MS);
-        resolve();
+        resolve(this);
       });
       this._wsClient.on('ping', () => {
         if (this._heartbeatTimeout) {
@@ -95,7 +95,7 @@ export default class EventChannelClient {
 
   disconnect() {
     this._isConnected = false;
-    this._wsClient.terminate();
+    this._wsClient!.terminate();
     if (this._heartbeatTimeout) {
       clearTimeout(this._heartbeatTimeout);
       this._heartbeatTimeout = null;
@@ -105,7 +105,7 @@ export default class EventChannelClient {
   startHeartbeatTimer(timeoutMs: number) {
     this._heartbeatTimeout = setTimeout(() => {
       console.log(`Connection timeout! Terminate the connection. All event subscriptions are stopped.`);
-      this._wsClient.terminate();
+      this._wsClient!.terminate();
     }, timeoutMs);
   }
 
@@ -182,7 +182,7 @@ export default class EventChannelClient {
     if (!this._isConnected) {
       throw Error(`Failed to send message. Event channel is not connected!`);
     }
-    this._wsClient.send(JSON.stringify(message));
+    this._wsClient!.send(JSON.stringify(message));
   }
 
   registerFilter(filter: EventFilter) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -862,6 +862,13 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.1.tgz#20f18294f797f2209b5f65c8e3b5c8e8261d127c"
   integrity sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==
 
+"@types/ws@^8.5.3":
+  version "8.5.3"
+  resolved "https://registry.yarnpkg.com/@types/ws/-/ws-8.5.3.tgz#7d25a1ffbecd3c4f2d35068d0b283c037003274d"
+  integrity sha512-6YOoWjruKj1uLf3INHH7D3qTXwFfEsg1kf3c0uDdSBJwfa/llkwIjrAGV7j7mVgGNbzTQ3HiHKKDXl6bJPD97w==
+  dependencies:
+    "@types/node" "*"
+
 "@types/yargs-parser@*":
   version "20.2.1"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-20.2.1.tgz#3b9ce2489919d9e4fea439b76916abc34b2df129"


### PR DESCRIPTION
Changes:
- Changed so that if the test fails in the middle, it does not wait for a timeout and ends immediately.
- Do not check that the tx state changes from PENDING to REVERTED in the 'Invalid transaction' test case.
- Delete event filters after each test.

If the test node is never selected as a proposer node, the tx in the PENDING state changes to the TIMED_OUT state after TX_POOL_TIMEOUT_MS, which is too long to wait for this in the test code.

Todo:
- Fix subscribe and unscribe login to wait response