### PR TITLE
Resolve concurrency problem and fix slack message

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -33,7 +33,7 @@ jobs:
         git add "package.json"
         git commit -m "Upgrade version to ${{ env.NEW_VERSION }}"
         git push origin release/v${{ env.NEW_VERSION }}
-        gh pr create -B master -H release/v${{ env.NEW_VERSION }} --title 'Upgrade version to ${{ env.NEW_VERSION }}' --body 'Upgrade version to ${{ env.NEW_VERSION }}'
-        gh pr create -B develop -H release/v${{ env.NEW_VERSION }} --title 'Release/v${{ env.NEW_VERSION }} -> develop' --body 'Upgrade version to ${{ env.NEW_VERSION }}'
+        gh pr create -B master -H release/v${{ env.NEW_VERSION }} -d --title 'Upgrade version to ${{ env.NEW_VERSION }}' --body 'Upgrade version to ${{ env.NEW_VERSION }}'
+        gh pr create -B develop -H release/v${{ env.NEW_VERSION }} -d --title 'Release/v${{ env.NEW_VERSION }} -> develop' --body 'Upgrade version to ${{ env.NEW_VERSION }}'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -2,7 +2,7 @@ name: Test Pipeline for opened PR
 on:
   pull_request:
     branches: [ master, develop ] #put your branches which you want to execute test pipeline
-    types: [ review_requested ]
+    types: [ opened, ready_for_review ]
 concurrency: 
       group: ${{ github.event.pull_request.number }}
       cancel-in-progress: true

--- a/.github/workflows/send_slack.yml
+++ b/.github/workflows/send_slack.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Get error log
         id: error_log
         run: |
-          ERROR_LOG="$(gh run view ${{ github.event.workflow_run.id }} --log-failed | tail -n 7 | sed -r 's/\x1B\[(([0-9]+)(;[0-9]+)*)?[m,K,H,f,J]//g' | sed -z 's/\n/\\n/g' | sed 's/\t/    /g')"
+          ERROR_LOG="$(gh run view ${{ github.event.workflow_run.id }} --log-failed | tail -n 7 | rev | cut -f 1 | rev | sed -r 's/\x1B\[(([0-9]+)(;[0-9]+)*)?[m,K,H,f,J]//g' | sed -z 's/\n/\\n/g' | sed 's/\t/    /g')"
           echo "ERROR_LOG=$ERROR_LOG" >> $GITHUB_OUTPUT
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -22,7 +22,7 @@ jobs:
         with:
           payload: |
             {
-              "text": "${{ github.event.workflow.name }} failed for <${{ github.server_url }}/${{ github.repository }}/pull/${{ env.PR_NUMBER }}|PR#${{ env.PR_NUMBER }}>",
+              "text": "${{ github.event.workflow.name }} failed",
               "blocks": [
                 {
                   "type": "header",
@@ -36,7 +36,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "${{ github.event.workflow.name }} failed for <${{ github.server_url }}/${{ github.repository }}/pull/${{ env.PR_NUMBER }}|PR#${{ env.PR_NUMBER }}>"
+                    "text": "${{ github.event.workflow.name }} failed"
                   }
                 },
                 {
@@ -49,6 +49,5 @@ jobs:
               ]
             }
         env:
-          PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK


### PR DESCRIPTION
Changes:
- Removed the pr number from the slack message because depending on the event that triggers the github workflow, the pr number may not be there.
- use `ready_for_review event` instead of `review_requested` (`review_requested` event is triggered many times when add many reviewers)
- Make error log shorter 
ex) 
```
2022-11-22T01:35:08.5003316Z Test Suites: 1 failed, 3 passed, 4 total
2022-11-22T01:35:08.5003599Z Tests:       1 failed, 78 passed, 79 total
2022-11-22T01:35:08.5003848Z Snapshots:   11 passed, 11 total 
2022-11-22T01:35:08.5004038Z Time:        443.19 s.
2022-11-22T01:35:08.5004234Z Ran all test suites.
2022-11-22T01:35:08.6365277Z error Command failed with exit code 1.
2022-11-22T01:35:08.6365735Z info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```