### PR TITLE
Release/v1.4.0

### DIFF
--- a/.github/workflows/pr_test_when_merged.yml
+++ b/.github/workflows/pr_test_when_merged.yml
@@ -21,12 +21,6 @@ jobs:
     if: ${{ github.base_ref == 'master' && github.event.pull_request.merged == true }}
     runs-on: ubuntu-latest
     steps:
-      - name: Context Test
-        run: |
-          echo ${{ github.base_ref }}
-          echo ${{ github.head_ref }}
-          echo ${{ github.event.pull_request.merged == true }}
-          echo ${{ startsWith(github.head_ref, 'release/') && (github.base_ref == 'master') && (github.event.pull_request.merged == true) }}
       - uses: actions/checkout@v3
       - name: Run test
         uses: ./

--- a/.github/workflows/pr_test_when_merged.yml
+++ b/.github/workflows/pr_test_when_merged.yml
@@ -8,7 +8,7 @@ concurrency:
       cancel-in-progress: true
 jobs:
   dump_github_context:
-  runs-on: ubuntu-latest
+    runs-on: ubuntu-latest
     steps:
       - name: Dump GitHub context
         env:

--- a/.github/workflows/pr_test_when_merged.yml
+++ b/.github/workflows/pr_test_when_merged.yml
@@ -33,7 +33,7 @@ jobs:
         uses: ./
         id: test-pipeline
   publish:
-    needs: [ run_test_on_mainnet ]
+    needs: run_test_on_mainnet
     if: ${{ startsWith(github.head_ref, 'release/') && (github.base_ref == 'master') && (github.event.pull_request.merged == true) }}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pr_test_when_merged.yml
+++ b/.github/workflows/pr_test_when_merged.yml
@@ -14,7 +14,7 @@ jobs:
         env:
           GITHUB_CONTEXT: ${{ toJson(github) }}
         run: echo "$GITHUB_CONTEXT"
-  run_test_on_testnet:
+  run_test_on_develop_branch:
     if: ${{ github.base_ref == 'develop' && github.event.pull_request.merged == true }}
     runs-on: ubuntu-latest
     steps:
@@ -24,7 +24,7 @@ jobs:
         id: test-pipeline
         with:
           environment: 'dev'
-  run_test_on_mainnet:
+  run_test_on_master_branch:
     if: ${{ github.base_ref == 'master' && github.event.pull_request.merged == true }}
     runs-on: ubuntu-latest
     steps:
@@ -33,7 +33,7 @@ jobs:
         uses: ./
         id: test-pipeline
   publish:
-    needs: run_test_on_mainnet
+    needs: run_test_on_master_branch
     if: ${{ startsWith(github.head_ref, 'release/') && (github.base_ref == 'master') && (github.event.pull_request.merged == true) }}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pr_test_when_merged.yml
+++ b/.github/workflows/pr_test_when_merged.yml
@@ -21,15 +21,25 @@ jobs:
     if: ${{ github.base_ref == 'master' && github.event.pull_request.merged == true }}
     runs-on: ubuntu-latest
     steps:
-      - name: test
+      - name: Context Test
         run: |
           echo ${{ github.base_ref }}
           echo ${{ github.head_ref }}
-          echo ${{ github }}
+          echo ${{ github.event.pull_request.merged == true }}
+          echo ${{ startsWith(github.head_ref, 'release/') && (github.base_ref == 'master') && (github.event.pull_request.merged == true) }}
       - uses: actions/checkout@v3
       - name: Run test
         uses: ./
         id: test-pipeline
+  contextTest:
+    needs: [ run_test_on_testnet, run_test_on_mainnet ]
+    steps:
+      - name: Context Test
+        run: |
+          echo ${{ github.base_ref }}
+          echo ${{ github.head_ref }}
+          echo ${{ github.event.pull_request.merged == true }}
+          echo ${{ startsWith(github.head_ref, 'release/') && (github.base_ref == 'master') && (github.event.pull_request.merged == true) }}
   publish:
     needs: [ run_test_on_testnet, run_test_on_mainnet ]
     if: ${{ startsWith(github.head_ref, 'release/') && (github.base_ref == 'master') && (github.event.pull_request.merged == true) }}

--- a/.github/workflows/pr_test_when_merged.yml
+++ b/.github/workflows/pr_test_when_merged.yml
@@ -7,6 +7,13 @@ concurrency:
       group: ${{ github.event.pull_request.number }}
       cancel-in-progress: true
 jobs:
+  dump_github_context:
+  runs-on: ubuntu-latest
+    steps:
+      - name: Dump GitHub context
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+        run: echo "$GITHUB_CONTEXT"
   run_test_on_testnet:
     if: ${{ github.base_ref == 'develop' && github.event.pull_request.merged == true }}
     runs-on: ubuntu-latest

--- a/.github/workflows/pr_test_when_merged.yml
+++ b/.github/workflows/pr_test_when_merged.yml
@@ -33,6 +33,7 @@ jobs:
         id: test-pipeline
   contextTest:
     needs: [ run_test_on_testnet, run_test_on_mainnet ]
+    runs-on: ubuntu-latest
     steps:
       - name: Context Test
         run: |

--- a/.github/workflows/pr_test_when_merged.yml
+++ b/.github/workflows/pr_test_when_merged.yml
@@ -31,18 +31,8 @@ jobs:
       - name: Run test
         uses: ./
         id: test-pipeline
-  contextTest:
-    needs: [ run_test_on_testnet, run_test_on_mainnet ]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Context Test
-        run: |
-          echo ${{ github.base_ref }}
-          echo ${{ github.head_ref }}
-          echo ${{ github.event.pull_request.merged == true }}
-          echo ${{ startsWith(github.head_ref, 'release/') && (github.base_ref == 'master') && (github.event.pull_request.merged == true) }}
   publish:
-    needs: [ run_test_on_testnet, run_test_on_mainnet ]
+    needs: [ run_test_on_mainnet ]
     if: ${{ startsWith(github.head_ref, 'release/') && (github.base_ref == 'master') && (github.event.pull_request.merged == true) }}
     runs-on: ubuntu-latest
     steps:
@@ -55,7 +45,6 @@ jobs:
         run: yarn
       - name: Publish package
         run: |
-          yarn
           yarn build
           yarn publish --access public
           echo "NEW_VERSION=$(npm pkg get version | tr -d '"')" >> $GITHUB_ENV

--- a/.github/workflows/pr_test_when_merged.yml
+++ b/.github/workflows/pr_test_when_merged.yml
@@ -21,6 +21,11 @@ jobs:
     if: ${{ github.base_ref == 'master' && github.event.pull_request.merged == true }}
     runs-on: ubuntu-latest
     steps:
+      - name: test
+        run: |
+          echo ${{ github.base_ref }}
+          echo ${{ github.head_ref }}
+          echo ${{ github }}
       - uses: actions/checkout@v3
       - name: Run test
         uses: ./
@@ -37,8 +42,6 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
       - name: Install dependencies
         run: yarn
-      - name: Test Success
-        run: yarn test
       - name: Publish package
         run: |
           yarn


### PR DESCRIPTION
Fixed pipeline and removed useless steps.

The reason why the publish step was skipped is that both `run_test_on_testnet` and `run_test_on_mainnet` were used in the publish needs, but if either one of them fails or is skipped, the entire publish step is also skipped.

reference: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idneeds