### PR TITLE
Add dryrun transaction APIs to ain-js

### DIFF
--- a/__tests__/__snapshots__/ain.test.ts.snap
+++ b/__tests__/__snapshots__/ain.test.ts.snap
@@ -141,7 +141,7 @@ Object {
   "#num_children": 2,
   "#num_children:username": 0,
   "#num_parents": 1,
-  "#num_parents:username": 2,
+  "#num_parents:username": 1,
   "#tree_bytes": 698,
   "#tree_bytes:username": 178,
   "#tree_height": 2,

--- a/__tests__/ain.test.ts
+++ b/__tests__/ain.test.ts
@@ -209,6 +209,7 @@ describe('ain-js', function() {
       const response = await ain.wallet.transfer({
         to: '0xbA58D93edD8343C001eC5f43E620712Ba8C10813', value: 100, nonce: -1
       }, true);  // isDryrun = true
+      expect(response.result.is_dryrun).toBe(true);
       const balanceAfter = await ain.wallet.getBalance();
       expect(balanceAfter).toBe(balanceBefore);  // NOT changed!
     });
@@ -387,6 +388,7 @@ describe('ain-js', function() {
       .then(res => {
         expect(res.result.code).toBe(0);
         expect(res.tx_hash).toEqual(expect.stringMatching(TX_PATTERN));
+        expect(res.result.is_dryrun).toBe(true);
         targetTxHash = res.tx_hash;
       })
       .catch(e => {
@@ -447,6 +449,7 @@ describe('ain-js', function() {
         expect(res.code).toBe(undefined);
         expect(res.tx_hash).toEqual(expect.stringMatching(TX_PATTERN));
         expect(res.result.code).toBe(0);
+        expect(res.result.is_dryrun).toBe(true);
       })
       .catch(e => {
         console.log("ERROR:", e);
@@ -673,6 +676,7 @@ describe('ain-js', function() {
       }, true)  // isDryrun = true
       .then(res => {
         expect(res.result.code).toBe(0);
+        expect(res.result.is_dryrun).toBe(true);
       })
       .catch((error) => {
         console.log("setOwner error:", error);
@@ -734,6 +738,7 @@ describe('ain-js', function() {
       }, true)  // isDryrun = true
       .then(res => {
         expect(res.result.code).toBe(0);
+        expect(res.result.is_dryrun).toBe(true);
       })
       .catch((error) => {
         console.log("setRule error:", error);
@@ -760,6 +765,7 @@ describe('ain-js', function() {
       }, true)  // isDryrun = true
       .then(res => {
         expect(res.result.code).toBe(0);
+        expect(res.result.is_dryrun).toBe(true);
       })
       .catch((error) => {
         console.log("setValue error:", error);
@@ -794,6 +800,7 @@ describe('ain-js', function() {
         }, true)  // isDryrun = true
         .then(res => {
           expect(res.result.code).toBe(0);
+          expect(res.result.is_dryrun).toBe(true);
         })
         .catch((error) => {
           console.log("setFunction error:", error);
@@ -849,7 +856,8 @@ describe('ain-js', function() {
         nonce: -1
       }, true)  // isDryrun = true
       .then(res => {
-        expect(Object.keys(res.result).length).toBe(4);
+        expect(Object.keys(res.result).length).toBe(5);
+        expect(res.result.is_dryrun).toBe(true);
       })
       .catch((error) => {
         console.log("set error:",error);
@@ -1023,10 +1031,11 @@ describe('ain-js', function() {
     });
 
     it('deleteValue with isDryrun = true', async function() {
-      await ain.db.ref(`${allowed_path}/can/write`).deleteValue()
+      await ain.db.ref(`${allowed_path}/can/write`).deleteValue({}, true)
       .then(res => {
         expect(res.result.code).toBe(0);
-      }, true)  // isDryrun = true
+        expect(res.result.is_dryrun).toBe(true);
+      })  // isDryrun = true
       .catch((error) => {
         console.log("deleteValue error:",error);
         fail('should not happen');

--- a/__tests__/ain.test.ts
+++ b/__tests__/ain.test.ts
@@ -397,7 +397,7 @@ describe('ain-js', function() {
       })
     });
 
-    it('getTransaction for dryrun', async function () {
+    it('getTransaction for sendTransaction with isDryrun = true', async function () {
       const tx = await ain.getTransaction(targetTxHash);
       expect(tx).toStrictEqual(null);  // The tx is NOT in the blockchain.
     });
@@ -415,7 +415,7 @@ describe('ain-js', function() {
       })
     });
 
-    it('getTransaction for send', async function () {
+    it('getTransaction for sendTransaction', async function () {
       const tx = await ain.getTransaction(targetTxHash);
       expect(tx.transaction.tx_body.operation).toStrictEqual(targetTx);
     });

--- a/src/ain-db/ref.ts
+++ b/src/ain-db/ref.ts
@@ -129,7 +129,7 @@ export default class Reference {
    * Any value given will be overwritten with null.
    * @return {Promise<any>}
    */
-  deleteValue(transactionInput?: ValueOnlyTransactionInput): Promise<any> {
+  deleteValue(transactionInput?: ValueOnlyTransactionInput, isDryrun: boolean = false): Promise<any> {
     let txInput: ValueOnlyTransactionInput = transactionInput || {};
     txInput['value'] = null;
     return this._ain.sendTransaction(
@@ -138,7 +138,8 @@ export default class Reference {
             Reference.extendPath(this.path, txInput.ref),
             "SET_VALUE",
             this._isGlobal
-        )
+        ),
+        isDryrun
     );
   }
 
@@ -146,14 +147,15 @@ export default class Reference {
    * Sets a function config.
    * @param transactionInput
    */
-  setFunction(transactionInput: ValueOnlyTransactionInput): Promise<any> {
+  setFunction(transactionInput: ValueOnlyTransactionInput, isDryrun: boolean = false): Promise<any> {
     return this._ain.sendTransaction(
         Reference.extendSetTransactionInput(
             transactionInput,
             Reference.extendPath(this.path, transactionInput.ref),
             "SET_FUNCTION",
             this._isGlobal
-        )
+        ),
+        isDryrun
     );
   }
 
@@ -162,14 +164,15 @@ export default class Reference {
    * @param {ValueOnlyTransactionInput} transactionInput - A transaction input object.
    * @return {Promise<any>}
    */
-  setOwner(transactionInput: ValueOnlyTransactionInput): Promise<any> {
+  setOwner(transactionInput: ValueOnlyTransactionInput, isDryrun: boolean = false): Promise<any> {
     return this._ain.sendTransaction(
         Reference.extendSetTransactionInput(
             transactionInput,
             Reference.extendPath(this.path, transactionInput.ref),
             "SET_OWNER",
             this._isGlobal
-        )
+        ),
+        isDryrun
     );
   }
 
@@ -178,14 +181,15 @@ export default class Reference {
    * @param {ValueOnlyTransactionInput} transactionInput - A transaction input object.
    * @return {Promise<any>}
    */
-  setRule(transactionInput: ValueOnlyTransactionInput): Promise<any> {
+  setRule(transactionInput: ValueOnlyTransactionInput, isDryrun: boolean = false): Promise<any> {
     return this._ain.sendTransaction(
         Reference.extendSetTransactionInput(
             transactionInput,
             Reference.extendPath(this.path, transactionInput.ref),
             "SET_RULE",
             this._isGlobal
-        )
+        ),
+        isDryrun
     );
   }
 
@@ -194,14 +198,15 @@ export default class Reference {
    * @param {ValueOnlyTransactionInput} transactionInput - A transaction input object.
    * @return {Promise<any>}
    */
-  setValue(transactionInput: ValueOnlyTransactionInput): Promise<any> {
+  setValue(transactionInput: ValueOnlyTransactionInput, isDryrun: boolean = false): Promise<any> {
     return this._ain.sendTransaction(
         Reference.extendSetTransactionInput(
             transactionInput,
             Reference.extendPath(this.path, transactionInput.ref),
             "SET_VALUE",
             this._isGlobal
-        )
+        ),
+        isDryrun
     );
   }
 
@@ -210,14 +215,15 @@ export default class Reference {
    * @param {ValueOnlyTransactionInput} transactionInput - A transaction input object.
    * @return {Promise<any>}
    */
-  incrementValue(transactionInput: ValueOnlyTransactionInput): Promise<any> {
+  incrementValue(transactionInput: ValueOnlyTransactionInput, isDryrun: boolean = false): Promise<any> {
     return this._ain.sendTransaction(
         Reference.extendSetTransactionInput(
             transactionInput,
             Reference.extendPath(this.path, transactionInput.ref),
             "INC_VALUE",
             this._isGlobal
-        )
+        ),
+        isDryrun
     );
   }
 
@@ -226,14 +232,15 @@ export default class Reference {
    * @param {ValueOnlyTransactionInput} transactionInput - A transaction input object.
    * @return {Promise<any>}
    */
-  decrementValue(transactionInput: ValueOnlyTransactionInput): Promise<any> {
+  decrementValue(transactionInput: ValueOnlyTransactionInput, isDryrun: boolean = false): Promise<any> {
     return this._ain.sendTransaction(
         Reference.extendSetTransactionInput(
             transactionInput,
             Reference.extendPath(this.path, transactionInput.ref),
             "DEC_VALUE",
             this._isGlobal
-        )
+        ),
+        isDryrun
     );
   }
 
@@ -242,9 +249,9 @@ export default class Reference {
    * @param {SetMultiTransactionInput} transactionInput - A transaction input object.
    * @return {Promise<any>}
    */
-  set(transactionInput: SetMultiTransactionInput): Promise<any> {
+  set(transactionInput: SetMultiTransactionInput, isDryrun: boolean = false): Promise<any> {
     return this._ain.sendTransaction(
-        Reference.extendSetMultiTransactionInput(transactionInput, this.path));
+        Reference.extendSetMultiTransactionInput(transactionInput, this.path), isDryrun);
   }
 
   /**

--- a/src/ain-db/ref.ts
+++ b/src/ain-db/ref.ts
@@ -127,6 +127,7 @@ export default class Reference {
    * Deletes a value.
    * @param {ValueOnlyTransactionInput} transactionInput - A transaction input object.
    * Any value given will be overwritten with null.
+   * @param {boolean} isDryrun - dryrun option.
    * @return {Promise<any>}
    */
   deleteValue(transactionInput?: ValueOnlyTransactionInput, isDryrun: boolean = false): Promise<any> {
@@ -146,6 +147,7 @@ export default class Reference {
   /**
    * Sets a function config.
    * @param transactionInput
+   * @param {boolean} isDryrun - dryrun option.
    */
   setFunction(transactionInput: ValueOnlyTransactionInput, isDryrun: boolean = false): Promise<any> {
     return this._ain.sendTransaction(
@@ -162,6 +164,7 @@ export default class Reference {
   /**
    * Sets the owner rule.
    * @param {ValueOnlyTransactionInput} transactionInput - A transaction input object.
+   * @param {boolean} isDryrun - dryrun option.
    * @return {Promise<any>}
    */
   setOwner(transactionInput: ValueOnlyTransactionInput, isDryrun: boolean = false): Promise<any> {
@@ -179,6 +182,7 @@ export default class Reference {
   /**
    * Sets the write rule.
    * @param {ValueOnlyTransactionInput} transactionInput - A transaction input object.
+   * @param {boolean} isDryrun - dryrun option.
    * @return {Promise<any>}
    */
   setRule(transactionInput: ValueOnlyTransactionInput, isDryrun: boolean = false): Promise<any> {
@@ -196,6 +200,7 @@ export default class Reference {
   /**
    * Sets a value.
    * @param {ValueOnlyTransactionInput} transactionInput - A transaction input object.
+   * @param {boolean} isDryrun - dryrun option.
    * @return {Promise<any>}
    */
   setValue(transactionInput: ValueOnlyTransactionInput, isDryrun: boolean = false): Promise<any> {
@@ -213,6 +218,7 @@ export default class Reference {
   /**
    * Increments the value.
    * @param {ValueOnlyTransactionInput} transactionInput - A transaction input object.
+   * @param {boolean} isDryrun - dryrun option.
    * @return {Promise<any>}
    */
   incrementValue(transactionInput: ValueOnlyTransactionInput, isDryrun: boolean = false): Promise<any> {
@@ -230,6 +236,7 @@ export default class Reference {
   /**
    * Decrements the value.
    * @param {ValueOnlyTransactionInput} transactionInput - A transaction input object.
+   * @param {boolean} isDryrun - dryrun option.
    * @return {Promise<any>}
    */
   decrementValue(transactionInput: ValueOnlyTransactionInput, isDryrun: boolean = false): Promise<any> {
@@ -247,6 +254,7 @@ export default class Reference {
   /**
    * Processes multiple set operations.
    * @param {SetMultiTransactionInput} transactionInput - A transaction input object.
+   * @param {boolean} isDryrun - dryrun option.
    * @return {Promise<any>}
    */
   set(transactionInput: SetMultiTransactionInput, isDryrun: boolean = false): Promise<any> {

--- a/src/ain.ts
+++ b/src/ain.ts
@@ -140,12 +140,7 @@ export default class Ain {
   async sendTransaction(transactionObject: TransactionInput): Promise<any> {
     const txBody = await this.buildTransactionBody(transactionObject);
     const signature = this.wallet.signTransaction(txBody, transactionObject.address);
-    let result = await this.provider.send('ain_sendSignedTransaction',
-        { signature, tx_body: txBody });
-    if (!result || typeof result !== 'object') {
-      result = { result };
-    }
-    return result;
+    return await this.sendSignedTransaction(signature, txBody);
   }
 
   /**

--- a/src/ain.ts
+++ b/src/ain.ts
@@ -135,6 +135,7 @@ export default class Ain {
   /**
    * Signs and sends a transaction to the network
    * @param {TransactionInput} transactionObject
+   * @param {boolean} isDryrun - dryrun option.
    * @return {Promise<any>}
    */
   async sendTransaction(transactionObject: TransactionInput, isDryrun: boolean = false): Promise<any> {
@@ -147,6 +148,7 @@ export default class Ain {
    * Sends a signed transaction to the network
    * @param {string} signature
    * @param {TransactionBody} txBody
+   * @param {boolean} isDryrun - dryrun option.
    * @return {Promise<any>}
    */
   async sendSignedTransaction(signature: string, txBody: TransactionBody, isDryrun: boolean = false): Promise<any> {
@@ -285,6 +287,7 @@ export default class Ain {
    * deposit/withdraw transaction and sends the transaction by calling sendTransaction().
    * @param {string} path
    * @param {ValueOnlyTransactionInput} transactionObject
+   * @param {boolean} isDryrun - dryrun option.
    * @return {Promise<any>}
    */
   private stakeFunction(path: string, transactionObject: ValueOnlyTransactionInput, isDryrun: boolean = false): Promise<any> {

--- a/src/ain.ts
+++ b/src/ain.ts
@@ -150,7 +150,7 @@ export default class Ain {
    * @return {Promise<any>}
    */
   async sendSignedTransaction(signature: string, txBody: TransactionBody, isDryrun: boolean = false): Promise<any> {
-    const method = isDryrun ? 'ain_dryrunSignedTransaction' : 'ain_sendSignedTransaction';
+    const method = isDryrun ? 'ain_sendSignedTransactionDryrun' : 'ain_sendSignedTransaction';
     let result = await this.provider.send(method, { signature, tx_body: txBody });
     if (!result || typeof result !== 'object') {
       result = { result };

--- a/src/ain.ts
+++ b/src/ain.ts
@@ -133,6 +133,17 @@ export default class Ain {
   }
 
   /**
+   * Signs and dryruns a transaction to the network
+   * @param {TransactionInput} transactionObject
+   * @return {Promise<any>}
+   */
+  async dryrunTransaction(transactionObject: TransactionInput): Promise<any> {
+    const txBody = await this.buildTransactionBody(transactionObject);
+    const signature = this.wallet.signTransaction(txBody, transactionObject.address);
+    return await this.dryrunSignedTransaction(signature, txBody);
+  }
+
+  /**
    * Signs and sends a transaction to the network
    * @param {TransactionInput} transactionObject
    * @return {Promise<any>}
@@ -141,6 +152,21 @@ export default class Ain {
     const txBody = await this.buildTransactionBody(transactionObject);
     const signature = this.wallet.signTransaction(txBody, transactionObject.address);
     return await this.sendSignedTransaction(signature, txBody);
+  }
+
+  /**
+   * Dryruns a signed transaction to the network
+   * @param {string} signature
+   * @param {TransactionBody} txBody
+   * @return {Promise<any>}
+   */
+  async dryrunSignedTransaction(signature: string, txBody: TransactionBody): Promise<any> {
+    let result = await this.provider.send('ain_dryrunSignedTransaction',
+        { signature, tx_body: txBody });
+    if (!result || typeof result !== 'object') {
+      result = { result };
+    }
+    return result;
   }
 
   /**

--- a/src/wallet.ts
+++ b/src/wallet.ts
@@ -221,12 +221,12 @@ export default class Wallet {
    * Sends a transfer transaction to the network.
    * @param input
    */
-  transfer(input: {to: string, value: number, from?: string, nonce?: number, gas_price?: number}): Promise<any> {
+  transfer(input: {to: string, value: number, from?: string, nonce?: number, gas_price?: number}, isDryrun: boolean = false): Promise<any> {
     const address = this.getImpliedAddress(input.from);
     const toAddress = Ain.utils.toChecksumAddress(input.to);
     const transferRef = this.ain.db.ref(`/transfer/${address}/${toAddress}`).push() as Reference;
     return transferRef.setValue({
-        ref: '/value', address, value: input.value, nonce: input.nonce, gas_price: input.gas_price });
+        ref: '/value', address, value: input.value, nonce: input.nonce, gas_price: input.gas_price }, isDryrun);
   }
 
   /**

--- a/src/wallet.ts
+++ b/src/wallet.ts
@@ -220,6 +220,7 @@ export default class Wallet {
   /**
    * Sends a transfer transaction to the network.
    * @param input
+   * @param {boolean} isDryrun - dryrun option.
    */
   transfer(input: {to: string, value: number, from?: string, nonce?: number, gas_price?: number}, isDryrun: boolean = false): Promise<any> {
     const address = this.getImpliedAddress(input.from);


### PR DESCRIPTION
Change summary:
- Add dryrun transactoin APIs
- Add tests for dryrun transaction APIs
- Update test for updated db restoring logic

Related issues:
- https://github.com/ainblockchain/ain-blockchain/issues/1182