### PR TITLE
Set minimal node version to 16 for typedocs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,7 +12,7 @@ jobs:
         fetch-depth: 0 # otherwise, you will failed to push refs to dest repo
     - uses: actions/setup-node@v3
       with:
-        node-version: 14 # typedoc require node version >= 14.14
+        node-version: 16 # typedoc@0.25.1 requires node version >= 16
     - name: Build Docs
       run: yarn && yarn docs
     - name: Deploy

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "docs": "yarn build && typedoc --out docs"
   },
   "engines": {
-    "node": ">=14"
+    "node": ">=16"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Change summary:
- Set minimal node version to 16 for typedocs