### PR TITLE
Add more typedoc comments to layer 1 classes, types, and interfaces

### DIFF
--- a/src/ain-db/ref.ts
+++ b/src/ain-db/ref.ts
@@ -324,12 +324,12 @@ export default class Reference {
     return this._ain.provider.send('ain_matchOwner', request);
   }
 
-  /**
-   * TODO(liayoo): Add this function.
-   * Attaches an listener for database events.
-   * @param {EventType} event - A type of event.
-   * @param {Function} callback function to be executed when an event occurs.
-   */
+  // TODO(liayoo): Add this function.
+  ///**
+  // * Attaches an listener for database events.
+  // * @param {EventType} event - A type of event.
+  // * @param {Function} callback function to be executed when an event occurs.
+  // */
   // on(event: EventType, callback: Function) {
   //   if (this._isRootReference) {
   //     throw new Error('[ain-js.Reference.on] Cannot attach an on() listener to a root node');
@@ -349,12 +349,12 @@ export default class Reference {
   //   }, 1000);
   // }
 
-  /**
-   * TODO (liayoo): Add this function
-   * Removes a database event listener.
-   * @param {EventType} event - A type of event.
-   * @param {Function} callback - A callback function to dettach from the event.
-   */
+  // TODO(liayoo): Add this function.
+  ///**
+  // * Removes a database event listener.
+  // * @param {EventType} event - A type of event.
+  // * @param {Function} callback - A callback function to dettach from the event.
+  // */
   // off(event?: EventType, callback?: Function) {
   //   if (!event && !callback) {
   //     this._listeners = {};

--- a/src/ain.ts
+++ b/src/ain.ts
@@ -173,7 +173,7 @@ export default class Ain {
   }
 
   /**
-   * Sends signed multiple transactions in a batch to the network.
+   * Signs and sends multiple transactions in a batch to the network.
    * @param {TransactionInput[]} transactionObjects The list of the transaction input objects.
    * @return {Promise<any>}
    */

--- a/src/ain.ts
+++ b/src/ain.ts
@@ -45,7 +45,6 @@ export default class Ain {
    * @param {string} providerUrl The endpoint URL of the network provider.
    * @param {number} chainId The chain ID of the blockchain network.
    * @param {AinOptions} ainOptions The options of the class.
-   * @constructor
    */
   constructor(providerUrl: string, chainId?: number, ainOptions?: AinOptions) {
     this.axiosConfig = ainOptions?.axiosConfig;

--- a/src/ain.ts
+++ b/src/ain.ts
@@ -16,19 +16,32 @@ import { Signer } from "./signer/signer";
 import { DefaultSigner } from './signer/default-signer';
 
 export default class Ain {
+  /** The axios request config object.  */
   public axiosConfig: AxiosRequestConfig | undefined;
+  /** The chain ID of the blockchain network. */
   public chainId: number;
+  /** The network provider object. */
   public provider: Provider;
+  /** The raw result mode option. */
   public rawResultMode: boolean;
+  /** The database object. */
   public db: Database;
+  /** The network object. */
   public net: Network;
+  /** The wallet object. */
   public wallet: Wallet;
+  /** The homorphic encryption object. */
   public he: HomomorphicEncryption;
+  /** The event manager object. */
   public em: EventManager;
+  /** The signer object. */
   public signer: Signer;
 
   /**
-   * @param {string} providerUrl
+   * Creates a new Ain object.
+   * @param {string} providerUrl The endpoint URL of the network provider.
+   * @param {number} chainId The chain ID of the blockchain network.
+   * @param {AinOptions} ainOptions The options of the class.
    * @constructor
    */
   constructor(providerUrl: string, chainId?: number, ainOptions?: AinOptions) {
@@ -45,8 +58,10 @@ export default class Ain {
   }
 
   /**
-   * Sets a new provider
-   * @param {string} providerUrl
+   * Sets a new provider.
+   * @param {string} providerUrl The endpoint URL of the network provider.
+   * @param {number} chainId The chain ID of the blockchain network.
+   * @param {AxiosRequestConfig} axiosConfig The axios request config.
    */
   setProvider(providerUrl: string, chainId?: number, axiosConfig?: AxiosRequestConfig | undefined) {
     if (axiosConfig) {
@@ -60,18 +75,18 @@ export default class Ain {
   }
 
   /**
-   * Sets a new signer
-   * @param {Signer} signer
+   * Sets a new signer.
+   * @param {Signer} signer The signer to set.
    */
   setSigner(signer: Signer) {
     this.signer = signer;
   }
 
   /**
-   * A promise returns a block with the given hash or block number.
-   * @param {string | number} blockHashOrBlockNumber
-   * @param {boolean} returnTransactionObjects - If true, returns the full transaction objects;
-   * otherwise, returns only the transaction hashes
+   * Fetches a block with a block hash or block number.
+   * @param {string | number} blockHashOrBlockNumber The block hash or block number.
+   * @param {boolean} returnTransactionObjects If it's true, returns a block with full transaction objects.
+   * Otherwise, returns a block with only transaction hashes.
    * @return {Promise<Block>}
    */
   getBlock(blockHashOrBlockNumber: string | number, returnTransactionObjects?: boolean): Promise<Block> {
@@ -84,8 +99,8 @@ export default class Ain {
   }
 
   /**
-   * A promise returns the address of the forger of given block
-   * @param {string | number} blockHashOrBlockNumber
+   * Fetches the forger's address of a block with a block hash or block number.
+   * @param {string | number} blockHashOrBlockNumber The block hash or block number.
    * @return {Promise<string>}
    */
   getProposer(blockHashOrBlockNumber: string | number): Promise<string> {
@@ -96,8 +111,8 @@ export default class Ain {
   }
 
   /**
-   * A promise returns the list of validators for a given block
-   * @param {string | number} blockHashOrBlockNumber
+   * Fetches the validator list of a block with a block hash or block number.
+   * @param {string | number} blockHashOrBlockNumber The block hash or block number.
    * @return {Promise<string[]>}
    */
   getValidators(blockHashOrBlockNumber: string | number): Promise<string[]> {
@@ -108,8 +123,8 @@ export default class Ain {
   }
 
   /**
-   * Returns the transaction with the given transaction hash.
-   * @param {string} transactionHash
+   * Fetches the information of a transaction with a transaction hash.
+   * @param {string} transactionHash The transaction hash.
    * @return {Promise<TransactionInfo>}
    */
   getTransaction(transactionHash: string): Promise<TransactionInfo> {
@@ -117,8 +132,8 @@ export default class Ain {
   }
 
   /**
-   * Returns the state usage information with the given app name.
-   * @param {string} appName
+   * Fetches the state usage information of a blockchain app.
+   * @param {string} appName The blockchain app name.
    * @return {Promise<StateUsageInfo>}
    */
   getStateUsage(appName: string): Promise<StateUsageInfo> {
@@ -126,16 +141,8 @@ export default class Ain {
   }
 
   /**
-   * Returns the result of the transaction with the given transaaction hash.
-   * @param {string} transactionHash
-   * @return {Promise<Transaction>}
-   */
-  // TODO(liayoo): implement this function.
-  // getTransactionResult(transactionHash: string): Promise<TransactionResult> {}
-
-  /**
-   * Validate the given app name.
-   * @param {string} appName
+   * Validates a blockchain app name.
+   * @param {string} appName The blockchain app name.
    * @return {Promise<AppNameValidationInfo>}
    */
   validateAppName(appName: string): Promise<AppNameValidationInfo> {
@@ -143,9 +150,9 @@ export default class Ain {
   }
 
   /**
-   * Signs and sends a transaction to the network
-   * @param {TransactionInput} transactionObject
-   * @param {boolean} isDryrun - dryrun option.
+   * Signs and sends a transaction to the network.
+   * @param {TransactionInput} transactionObject The transaction input object. 
+   * @param {boolean} isDryrun The dryrun option.
    * @return {Promise<any>}
    */
   async sendTransaction(transactionObject: TransactionInput, isDryrun: boolean = false): Promise<any> {
@@ -153,10 +160,10 @@ export default class Ain {
   }
 
   /**
-   * Sends a signed transaction to the network
-   * @param {string} signature
-   * @param {TransactionBody} txBody
-   * @param {boolean} isDryrun - dryrun option.
+   * Sends a signed transaction to the network.
+   * @param {string} signature The signature of the transaction.
+   * @param {TransactionBody} txBody The transaction body.
+   * @param {boolean} isDryrun The dryrun option.
    * @return {Promise<any>}
    */
   async sendSignedTransaction(signature: string, txBody: TransactionBody, isDryrun: boolean = false): Promise<any> {
@@ -164,8 +171,9 @@ export default class Ain {
   }
 
   /**
-   * Sends signed transactions to the network.
-   * @param {TransactionInput[]} transactionObjects
+   * Sends signed multiple transactions in a batch to the network.
+   * @param {TransactionInput[]} transactionObjects The list of the transaction input objects.
+   * @return {Promise<any>}
    */
   async sendTransactionBatch(transactionObjects: TransactionInput[]): Promise<any> {
     return this.signer.sendTransactionBatch(transactionObjects);
@@ -173,7 +181,7 @@ export default class Ain {
 
   /**
    * Sends a transaction that deposits AIN for consensus staking.
-   * @param {ValueOnlyTransactionInput} transactionObject
+   * @param {ValueOnlyTransactionInput} transactionObject The transaction input object.
    * @return {Promise<any>}
    */
   depositConsensusStake(transactionObject: ValueOnlyTransactionInput): Promise<any> {
@@ -182,7 +190,7 @@ export default class Ain {
 
   /**
    * Sends a transaction that withdraws AIN for consensus staking.
-   * @param {ValueOnlyTransactionInput} transactionObject
+   * @param {ValueOnlyTransactionInput} transactionObject The transaction input object.
    * @return {Promise<any>}
    */
   withdrawConsensusStake(transactionObject: ValueOnlyTransactionInput): Promise<any> {
@@ -190,8 +198,9 @@ export default class Ain {
   }
 
   /**
-   * Gets the amount of AIN currently staked for participating in consensus protocol.
-   * @param {string} account - If not specified, will try to use the defaultAccount value.
+   * Fetches the amount of AIN currently staked for participating in consensus protocol.
+   * @param {string} account The account to fetch the value with. If not specified,
+   * the default account of the signer is used.
    * @return {Promise<number>}
    */
   getConsensusStakeAmount(account?: string): Promise<number> {
@@ -201,15 +210,15 @@ export default class Ain {
   }
 
   /**
-   * Getter for ain-util library
+   * Getter for ain-util library.
    */
   static get utils() {
     return AinUtil;
   }
 
   /**
-   * Checks whether a given object is an instance of TransactionBody interface.
-   * @param {string} account
+   * Checks whether an object is an instance of the TransactionBody interface.
+   * @param {any} object The object to check.
    * @return {boolean}
    */
   static instanceofTransactionBody(object: any): object is TransactionBody {
@@ -220,9 +229,9 @@ export default class Ain {
   /**
    * A base function for all staking related database changes. It builds a
    * deposit/withdraw transaction and sends the transaction by calling sendTransaction().
-   * @param {string} path
-   * @param {ValueOnlyTransactionInput} transactionObject
-   * @param {boolean} isDryrun - dryrun option.
+   * @param {string} path The path to set a value.
+   * @param {ValueOnlyTransactionInput} transactionObject The transaction input object.
+   * @param {boolean} isDryrun The dryrun option.
    * @return {Promise<any>}
    */
   private stakeFunction(path: string, transactionObject: ValueOnlyTransactionInput, isDryrun: boolean = false): Promise<any> {

--- a/src/ain.ts
+++ b/src/ain.ts
@@ -125,7 +125,7 @@ export default class Ain {
   }
 
   /**
-   * Fetches the information of a transaction with a transaction hash.
+   * Fetches a transaction's information with a transaction hash.
    * @param {string} transactionHash The transaction hash.
    * @return {Promise<TransactionInfo>}
    */
@@ -134,7 +134,7 @@ export default class Ain {
   }
 
   /**
-   * Fetches the state usage information of a blockchain app.
+   * Fetches a blockchain app's state usage information with an app name.
    * @param {string} appName The blockchain app name.
    * @return {Promise<StateUsageInfo>}
    */
@@ -143,7 +143,7 @@ export default class Ain {
   }
 
   /**
-   * Validates a blockchain app name.
+   * Validates a blockchain app's name.
    * @param {string} appName The blockchain app name.
    * @return {Promise<AppNameValidationInfo>}
    */
@@ -219,7 +219,7 @@ export default class Ain {
   }
 
   /**
-   * Checks whether an object is an instance of the TransactionBody interface.
+   * Checks whether an object is an instance of TransactionBody interface.
    * @param {any} object The object to check.
    * @return {boolean}
    */
@@ -231,7 +231,7 @@ export default class Ain {
   /**
    * A base function for all staking related database changes. It builds a
    * deposit/withdraw transaction and sends the transaction by calling sendTransaction().
-   * @param {string} path The path to set a value.
+   * @param {string} path The path to set a value with.
    * @param {ValueOnlyTransactionInput} transactionObject The transaction input object.
    * @param {boolean} isDryrun The dryrun option.
    * @return {Promise<any>}

--- a/src/ain.ts
+++ b/src/ain.ts
@@ -15,6 +15,9 @@ import HomomorphicEncryption from './he';
 import { Signer } from "./signer/signer";
 import { DefaultSigner } from './signer/default-signer';
 
+/**
+ * The main class of the ain-js SDK library.
+ */
 export default class Ain {
   /** The axios request config object.  */
   public axiosConfig: AxiosRequestConfig | undefined;

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,6 +1,15 @@
+/**
+ * A class for blockchain errors.
+ */
 export class BlockchainError extends Error {
+  /** The error code. */
   public code: number;
 
+  /**
+   * Creates a new BlockchainError object.
+   * @param {number} code The error code.
+   * @param {string} message The error message.
+   */
   constructor(code: number, message: string) {
     super(message);
     // NOTE(platfowner): https://stackoverflow.com/questions/68899615/how-to-expect-a-custom-error-to-be-thrown-with-jest

--- a/src/event-manager/event-channel-client.ts
+++ b/src/event-manager/event-channel-client.ts
@@ -4,7 +4,7 @@ import {
   EventChannelMessageTypes,
   EventChannelMessage,
   BlockchainEventTypes,
-  EventChannelConnectionOption,
+  EventChannelConnectionOptions,
   DisconnectCallback,
 } from '../types';
 import EventFilter from './event-filter';
@@ -34,7 +34,7 @@ export default class EventChannelClient {
     return this._isConnected;
   }
 
-  connect(connectionOption: EventChannelConnectionOption, disconnectCallback?: DisconnectCallback) {
+  connect(connectionOption: EventChannelConnectionOptions, disconnectCallback?: DisconnectCallback) {
     return new Promise(async (resolve, reject) => {
       if (this.isConnected) {
         reject(new Error(`Can't connect multiple channels`));

--- a/src/event-manager/index.ts
+++ b/src/event-manager/index.ts
@@ -2,7 +2,7 @@ import Ain from '../ain';
 import {
   BlockFinalizedEventConfig, BlockFinalizedEvent,
   ErrorFirstCallback,
-  EventChannelConnectionOption,
+  EventChannelConnectionOptions,
   EventConfigType, BlockchainEventCallback,
   TxStateChangedEventConfig, TxStateChangedEvent,
   ValueChangedEventConfig, ValueChangedEvent, DisconnectCallback, FilterDeletedEventCallback,
@@ -22,7 +22,7 @@ export default class EventManager {
     this._eventChannelClient = new EventChannelClient(ain, this._eventCallbackManager);
   }
 
-  async connect(connectionOption?: EventChannelConnectionOption, disconnectCallback?: DisconnectCallback) {
+  async connect(connectionOption?: EventChannelConnectionOptions, disconnectCallback?: DisconnectCallback) {
     await this._eventChannelClient.connect(connectionOption || {}, disconnectCallback);
   }
 

--- a/src/net.ts
+++ b/src/net.ts
@@ -6,13 +6,14 @@ import { BLOCKCHAIN_PROTOCOL_VERSION } from './constants';
  * A class for checking the blockchain node status.
  */
 export default class Network {
+  /** The network provider. */
   public provider: Provider;
+  /** The protocol version. */
   public protoVer: string;
 
   /**
    * Creates a new Network object.
    * @param {Provider} provider The network provider.
-   * @constructor
    */
   constructor (provider: Provider) {
     this.provider = provider;

--- a/src/net.ts
+++ b/src/net.ts
@@ -2,12 +2,16 @@ import * as semver from 'semver';
 import Provider from './provider';
 import { BLOCKCHAIN_PROTOCOL_VERSION } from './constants';
 
+/**
+ * A class for checking the blockchain node status.
+ */
 export default class Network {
   public provider: Provider;
   public protoVer: string;
 
   /**
-   * @param {Provider} provider
+   * Creates a new Network object.
+   * @param {Provider} provider The network provider.
    * @constructor
    */
   constructor (provider: Provider) {
@@ -16,7 +20,7 @@ export default class Network {
   }
 
   /**
-   * Returns whether the node is listening for network connections.
+   * Checks whether the blockchain node is listening for network connections.
    * @return {Promise<boolean>}
    */
   isListening(): Promise<boolean> {
@@ -24,28 +28,28 @@ export default class Network {
   }
 
   /**
-   * Returns the id of the network the node is connected to.
+   * Fetches the ID of the network the blokchain node is connected to.
    */
   getNetworkId(): Promise<string> {
     return this.provider.send('net_getNetworkId');
   }
 
   /**
-   * Checks the protocol version.
+   * Checks the protocol version compatibility with the blockchain node.
    */
   async checkProtocolVersion(): Promise<any> {
     return this.provider.send('ain_checkProtocolVersion');
   }
 
   /**
-   * Returns the protocol version of the node.
+   * Fetches the protocol version of the blockchain node.
    */
   getProtocolVersion(): Promise<any> {
     return this.provider.send('ain_getProtocolVersion');
   }
 
   /**
-   * Returns the number of peers the provider node is connected to.
+   * Fetches the number of the peers the blockchain node is connected to.
    * @return {Promise<number>}
    */
   getPeerCount(): Promise<number> {
@@ -53,7 +57,7 @@ export default class Network {
   }
 
   /**
-   * Returns whether the node is syncing with the network or not.
+   * Checks whether the blockchain node is syncing with the network or not.
    * @return {Promise<boolean>}
    */
   isSyncing(): Promise<boolean> {
@@ -61,7 +65,7 @@ export default class Network {
   }
 
   /**
-   * Returns the event handler network information.
+   * Fetches the event handler network information.
    */
   getEventHandlerNetworkInfo(): Promise<any> {
     return this.provider.send('net_getEventHandlerNetworkInfo');

--- a/src/promi-event.ts
+++ b/src/promi-event.ts
@@ -1,16 +1,24 @@
 import * as EventEmitter from 'eventemitter3';
 
 /**
- * A combination of a promise and an event emitter.
+ * A class that combines the Promise interface and the EventEmitter class.
  * @implements {Promise<T>}
  */
 export class PromiEvent<T> implements Promise<T> {
+  /** The event emitter. */
   public eventEmitter: EventEmitter;
+  /** The promise. */
   public promise: Promise<T>
+  /** The value for toString(). */
   public [Symbol.toStringTag];
+  /** The resolve function. */
   private _resolve;
+  /** The reject function. */
   private _reject;
 
+  /**
+   * Creates a new PromiEvent object.
+   */
   constructor() {
     this.promise = new Promise((resolve, reject) => {
       this._resolve = resolve;
@@ -21,6 +29,7 @@ export class PromiEvent<T> implements Promise<T> {
     this[Symbol.toStringTag] = 'Promise';
   }
 
+  /** The then method. */
   then<TResult1 = T, TResult2 = never>(
     onfulfilled?: ((value: T) =>
       TResult1 | PromiseLike<TResult1>) | undefined | null,
@@ -30,6 +39,7 @@ export class PromiEvent<T> implements Promise<T> {
       return this.promise.then(onfulfilled, onrejected)
     }
 
+  /** The catch method. */
   catch<TResult = never>(
     onrejected?: ((reason: any) =>
       TResult | PromiseLike<TResult>) | undefined | null
@@ -37,18 +47,23 @@ export class PromiEvent<T> implements Promise<T> {
       return this.promise.then(onrejected)
     }
 
+  /** The finally method. */
   finally(onfinally?: (() => void) | undefined | null): Promise<T> {
     return this.promise;
   }
 
+  /** The resolve method. */
   resolve(val:T) { this._resolve(val) }
+  /** The reject method. */
   reject(reason:any) { this._reject(reason) }
 
+  /** The once method. */
   once(type: string, handler: (res: any) => void): PromiEvent<T> {
     this.eventEmitter.once(type, handler);
     return this;
   };
 
+  /** The on method. */
   on(type: string, handler: (res: any) => void): PromiEvent<T> {
     this.eventEmitter.on(type, handler);
     return this;

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -6,15 +6,24 @@ import { BlockchainError } from './errors';
 
 const JSON_RPC_ENDPOINT = 'json-rpc';
 
+/**
+ * A class for providing JSON-RPC channels with blockchain node endpoints.
+ */
 export default class Provider {
+  /** The blockchain node endpoint. */
   public endpoint: string;
+  /** The blockchain node JSON-RPC endpoint. */
   public apiEndpoint: string;
+  /** The Ain object. */
   private ain: Ain;
+  /** The axios http client object. */
   private httpClient: AxiosInstance;
 
   /**
-   * @param {String} endpoint
-   * @constructor
+   * Creates a new Provider object.
+   * @param {Ain} ain The Ain object.
+   * @param {string} endpoint The blockchain node endpoint.
+   * @param {AxiosRequestConfig} axiosConfig The axios request config object.
    */
   constructor(ain: Ain, endpoint: string, axiosConfig: AxiosRequestConfig | undefined) {
     this.ain = ain;
@@ -29,9 +38,9 @@ export default class Provider {
   }
 
   /**
-   * Creates the JSON-RPC payload and sends it to the node.
-   * @param {string} rpcMethod
-   * @param {any} params
+   * Creates a JSON-RPC payload and sends it to the network.
+   * @param {string} rpcMethod The JSON-RPC method.
+   * @param {any} params The JSON-RPC parameters.
    * @return {Promise<any>}
    */
   async send(rpcMethod: string, params?: any): Promise<any> {
@@ -53,8 +62,8 @@ export default class Provider {
   }
 
   /**
-   * Sets the httpClient's default timeout time
-   * @param {number} time (in milliseconds)
+   * Sets the http client's default timeout value.
+   * @param {number} time The timeout value (in milliseconds).
    */
   setDefaultTimeoutMs(time: number) {
     this.httpClient.defaults.timeout = time;

--- a/src/request.ts
+++ b/src/request.ts
@@ -1,9 +1,0 @@
-// This is a mock module for sending requests and having delays.
-export default function request(url: string) {
-  return new Promise(resolve => {
-    process.nextTick(() => {
-      if (url.includes("Count") || url.includes("Amount")) resolve(31);
-      resolve('test_string');
-    });
-  });
-}

--- a/src/types.ts
+++ b/src/types.ts
@@ -38,7 +38,7 @@ export interface KdfParams {
 }
 
 /**
- * An interface for V3Keystore options.
+ * An interface for v3 keystore options.
  */
 export interface V3KeystoreOptions {
   salt?: string;
@@ -386,9 +386,9 @@ export interface TxStateChangedEventConfig {
 export type EventConfigType = BlockFinalizedEventConfig | ValueChangedEventConfig | TxStateChangedEventConfig;
 
 /**
- * An interface for event-channel-connection option (blockchain event handler).
+ * An interface for event-channel-connection options (blockchain event handler).
  */
-export interface EventChannelConnectionOption {
+export interface EventChannelConnectionOptions {
   handshakeTimeout?: number;
   heartbeatIntervalMs?: number;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,7 +25,7 @@ export interface Account {
 export interface Accounts {[address: string]: Account}
 
 /**
- * The key derivation function parameters.
+ * An interface for key derivation function parameters.
  */
 export interface KdfParams {
   dklen: number;
@@ -144,7 +144,7 @@ export interface GetOperation extends GetOptions {
 }
 
 /**
- * An interface for transactions body base.
+ * An interface for transaction body base.
  */
 export interface TransactionBodyBase {
   parent_tx_hash?: string;
@@ -274,7 +274,7 @@ export interface EvalRuleInput {
 }
 
 /**
- * An interface for eval owner (EVAL_RULE) input.
+ * An interface for eval owner (EVAL_OWNER) input.
  */
 export interface EvalOwnerInput {
   ref?: string;
@@ -361,7 +361,7 @@ export interface BlockFinalizedEventConfig {
 }
 
 /**
- * A type for value changed event source (blockchain event handler).
+ * A type for value-changed event source (blockchain event handler).
  */
 export type ValueChangedEventSource = 'BLOCK' | 'USER';
 
@@ -394,7 +394,7 @@ export interface EventChannelConnectionOption {
 }
 
 /**
- * An interface for error handling (blockchain event handler).
+ * An interface for error handling callbacks (blockchain event handler).
  */
 export interface ErrorFirstCallback<T> {
   (err: any, result?: undefined | null): void;

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,14 +7,26 @@ declare global {
   }
 }
 
+/**
+ * An interface for account.
+ */
 export interface Account {
+  /** The address. */
   address: string;
+  /** The private key. */
   private_key: string;
+  /** The public key. */
   public_key: string;
 }
 
+/**
+ * An interface for account list.
+ */
 export interface Accounts {[address: string]: Account}
 
+/**
+ * The key derivation function parameters.
+ */
 export interface KdfParams {
   dklen: number;
   salt: string;
@@ -25,6 +37,9 @@ export interface KdfParams {
   p?: number;
 }
 
+/**
+ * An interface for V3Keystore options.
+ */
 export interface V3KeystoreOptions {
   salt?: string;
   iv?: Buffer;
@@ -39,6 +54,9 @@ export interface V3KeystoreOptions {
   uuid?: Buffer;
 }
 
+/**
+ * An interface for keystore files in Ethereum wallet format version 3.
+ */
 export interface V3Keystore {
   version: 3;
   id: string;
@@ -55,23 +73,41 @@ export interface V3Keystore {
   };
 }
 
+/**
+ * A type for Ain options.
+ */
 export type AinOptions = {
+  /** The raw result mode option. */
   rawResultMode?: boolean;
+  /** The axios request config object.  */
   axiosConfig?: AxiosRequestConfig | undefined;
 }
 
 // export type EventType = "value" | "child_added" | "child_changed" | "child_removed";
 
+/**
+ * A type for multi-set (SET) operation type value.
+ */
 export type SetMultiOperationType = "SET";
 
-export type GetMultiOperationType = "GET";
-
+/**
+ * A type for set operation type values.
+ */
 export type SetOperationType = "SET_VALUE" | "INC_VALUE" | "DEC_VALUE" | "SET_RULE" | "SET_OWNER" | "SET_FUNCTION";
 
+/**
+ * A type for get operation type values.
+ */
 export type GetOperationType = "GET_VALUE" | "GET_RULE" | "GET_OWNER" | "GET_FUNCTION";
 
+/**
+ * A type for owner permission values.
+ */
 export type OwnerPermission = "branch_owner" | "write_function" | "write_owner" | "write_rule";
 
+/**
+ * A type for blockchain get API options.
+ */
 export type GetOptions = {
   is_global?: boolean;
   is_final?: boolean;
@@ -81,6 +117,9 @@ export type GetOptions = {
   include_proof?: boolean;
 }
 
+/**
+ * An interface for blockchain set operation.
+ */
 export interface SetOperation {
   type: SetOperationType;
   ref: string;
@@ -88,26 +127,33 @@ export interface SetOperation {
   is_global?: boolean;
 }
 
+/**
+ * An interface for blockchain multi-set (SET) operation.
+ */
 export interface SetMultiOperation {
   type: SetMultiOperationType;
   op_list: SetOperation[];
 }
 
+/**
+ * An interface for blockchain get operation.
+ */
 export interface GetOperation extends GetOptions {
   type: GetOperationType;
   ref?: string;
 }
 
-export interface GetMultiOperation {
-  type: GetMultiOperationType;
-  op_list: GetOperation[];
-}
-
+/**
+ * An interface for transactions body base.
+ */
 export interface TransactionBodyBase {
   parent_tx_hash?: string;
   operation: SetOperation | SetMultiOperation;
 }
 
+/**
+ * An interface for value-only transaction body base.
+ */
 export interface ValueOnlyTransactionBodyBase {
   parent_tx_hash?: string;
   value?: any;
@@ -115,6 +161,9 @@ export interface ValueOnlyTransactionBodyBase {
   is_global?: boolean;
 }
 
+/**
+ * An interface for transaction input base.
+ */
 export interface TransactionInputBase {
   nonce?: number;
   address?: string;
@@ -123,6 +172,9 @@ export interface TransactionInputBase {
   billing?: string;
 }
 
+/**
+ * An interface for transaction body.
+ */
 export interface TransactionBody extends TransactionBodyBase {
   nonce: number;
   timestamp: number;
@@ -130,15 +182,27 @@ export interface TransactionBody extends TransactionBodyBase {
   billing?: string;
 }
 
+/**
+ * An interface for transaction input.
+ */
 export interface TransactionInput extends TransactionBodyBase, TransactionInputBase {}
 
+/**
+ * An interface for value-only transaction input.
+ */
 export interface ValueOnlyTransactionInput extends ValueOnlyTransactionBodyBase, TransactionInputBase {}
 
+/**
+ * An interface for multi-set (SET) transaction input.
+ */
 export interface SetMultiTransactionInput extends TransactionInputBase {
   parent_tx_hash?: string;
   op_list?: SetOperation[];
 }
 
+/**
+ * An interface for transaction.
+ */
 export interface Transaction {
   tx_body: TransactionBody;
   signature: string;
@@ -146,6 +210,9 @@ export interface Transaction {
   address: string;
 }
 
+/**
+ * An interface for transaction information.
+ */
 export interface TransactionInfo {
   transaction: Transaction;
   status: string;
@@ -156,6 +223,9 @@ export interface TransactionInfo {
   finalized_at: number;
 }
 
+/**
+ * An interface for transaction result.
+ */
 export interface TransactionResult {
   status: boolean;
   block_hash?: string;
@@ -166,6 +236,9 @@ export interface TransactionResult {
   parent_tx_hash?: string;
 }
 
+/**
+ * An interface for blockchain block.
+ */
 export interface Block {
   number: number;
   epoch: number;
@@ -182,10 +255,16 @@ export interface Block {
   transactions_hash: string;
 }
 
+/**
+ * An interface for listener map.
+ */
 export interface ListenerMap {
   [key: string]: Function[];
 }
 
+/**
+ * An interface for eval rule (EVAL_RULE) input.
+ */
 export interface EvalRuleInput {
   value: any;
   ref?: string;
@@ -194,6 +273,9 @@ export interface EvalRuleInput {
   is_global?: boolean;
 }
 
+/**
+ * An interface for eval owner (EVAL_RULE) input.
+ */
 export interface EvalOwnerInput {
   ref?: string;
   address?: string;
@@ -201,33 +283,51 @@ export interface EvalOwnerInput {
   is_global?: boolean;
 }
 
+/**
+ * An interface for match input.
+ */
 export interface MatchInput {
   ref?: string;
   is_global?: boolean;
 }
 
+/**
+ * An interface for state usage information.
+ */
 export interface StateUsageInfo {
   tree_height?: number;
   tree_size?: number;
   tree_bytes?: number;
 }
 
+/**
+ * An interface for app name validation information.
+ */
 export interface AppNameValidationInfo {
   is_valid: boolean;
   code: number;
   message?: string;
 }
 
+/**
+ * A type for homomorphic encryption (HE) parameters.
+ */
 export type HomomorphicEncryptionParams = {
   polyModulusDegree: number;
   coeffModulusArray: Int32Array;
   scaleBit: number;
 }
 
+/**
+ * A type for homomorphic encryption (HE) secret key.
+ */
 export type HomomorphicEncryptionSecretKey = {
   secretKey: string;
 }
 
+/**
+ * Blockchain event types for blockchain event handler.
+ */
 export enum BlockchainEventTypes {
   BLOCK_FINALIZED = 'BLOCK_FINALIZED',
   VALUE_CHANGED = 'VALUE_CHANGED',
@@ -235,6 +335,9 @@ export enum BlockchainEventTypes {
   FILTER_DELETED = 'FILTER_DELETED',
 }
 
+/**
+ * Event channel message types for blockchain event handler.
+ */
 export enum EventChannelMessageTypes {
   REGISTER_FILTER = 'REGISTER_FILTER',
   DEREGISTER_FILTER = 'DEREGISTER_FILTER',
@@ -242,48 +345,81 @@ export enum EventChannelMessageTypes {
   EMIT_ERROR = 'EMIT_ERROR',
 }
 
+/**
+ * An interface for event channel message (blockchain event handler).
+ */
 export interface EventChannelMessage {
   type: EventChannelMessageTypes;
   data: any;
 }
 
+/**
+ * An interface for block-finalized event configuration (blockchain event handler).
+ */
 export interface BlockFinalizedEventConfig {
   block_number: number | null;
 }
 
+/**
+ * A type for value changed event source (blockchain event handler).
+ */
 export type ValueChangedEventSource = 'BLOCK' | 'USER';
 
+/**
+ * An interface for value-changed event configuraiton (blockchain event handler).
+ */
 export interface ValueChangedEventConfig {
   path: string;
   event_source: ValueChangedEventSource | null;
 }
 
+/**
+ * An interface for transaction-state-changed event configuration (blockchain event handler).
+ */
 export interface TxStateChangedEventConfig {
   tx_hash: string;
 }
 
+/**
+ * A type for event configuration (blockchain event handler).
+ */
 export type EventConfigType = BlockFinalizedEventConfig | ValueChangedEventConfig | TxStateChangedEventConfig;
 
+/**
+ * An interface for event-channel-connection option (blockchain event handler).
+ */
 export interface EventChannelConnectionOption {
   handshakeTimeout?: number;
   heartbeatIntervalMs?: number;
 }
 
+/**
+ * An interface for error handling (blockchain event handler).
+ */
 export interface ErrorFirstCallback<T> {
   (err: any, result?: undefined | null): void;
   (err: undefined | null, result: T): void;
 }
 
+/**
+ * An interface for block-finalized event (blockchain event handler).
+ */
 export interface BlockFinalizedEvent {
   block_number: number;
   block_hash: string;
 }
 
+/**
+ * An interface for value-changed event authentication (blockchain event handler).
+ */
 export interface ValueChangedEventAuth {
   addr?: string;
   fid?: string;
 }
 
+/**
+ * An interface for value-changed event (blockchain event handler).
+ */
 export interface ValueChangedEvent {
   filter_path: string;
   matched_path: string;
@@ -297,6 +433,9 @@ export interface ValueChangedEvent {
   };
 }
 
+/**
+ * Transaction states for transaction-state-changed event (blockchain event handler).
+ */
 export enum TransactionStates {
   FINALIZED = 'FINALIZED',
   REVERTED = 'REVERTED',  // Failed but included in a block
@@ -307,6 +446,9 @@ export enum TransactionStates {
   TIMED_OUT = 'TIMED_OUT',
 };
 
+/**
+ * An interface for transaction-state-changed event (blockchain event handler).
+ */
 export interface TxStateChangedEvent {
   transaction: Transaction;
   tx_state: {
@@ -315,22 +457,37 @@ export interface TxStateChangedEvent {
   };
 }
 
+/**
+ * Filter deletion reasons (blockchain event handler).
+ */
 export enum FilterDeletionReasons {
   FILTER_TIMEOUT = 'FILTER_TIMEOUT',
   END_STATE_REACHED = 'END_STATE_REACHED',
 }
 
+/**
+ * An interface for filter-deleted event (blockchain event handler).
+ */
 export interface FilterDeletedEvent {
   filter_id: string;
   reason: FilterDeletionReasons;
 }
 
+/**
+ * An interface for blockchain event callback (blockchain event handler).
+ */
 export interface BlockchainEventCallback {
   (event: BlockFinalizedEvent): void;
   (event: ValueChangedEvent): void;
   (event: TxStateChangedEvent): void;
 }
 
+/**
+ * A type for filter-deleted event callback (blockchain event handler).
+ */
 export type FilterDeletedEventCallback = (event: FilterDeletedEvent) => void;
 
+/**
+ * A type for disconnected callback (blockchain event handler).
+ */
 export type DisconnectCallback = (webSocket) => void;

--- a/src/wallet.ts
+++ b/src/wallet.ts
@@ -59,9 +59,9 @@ export default class Wallet {
   }
 
   /**
-   * Creates {numberOfAccounts} new accounts and adds them to the wallet.
-   * @param {number} numberOfAccounts
-   * @return {Array<string>} The created new accounts.
+   * Creates new accounts and adds them to the wallet.
+   * @param {number} numberOfAccounts The number of accounts to create.
+   * @return {Array<string>} The newly created accounts.
    */
   create(numberOfAccounts: number): Array<string> {
     if (numberOfAccounts <= 0) throw Error("numberOfAccounts should be greater than 0.");
@@ -139,7 +139,7 @@ export default class Wallet {
   }
 
   /**
-   * Adds an account from a V3 Keystore.
+   * Adds an account from a v3 keystore.
    * @param {V3Keystore | string} v3Keystore The v3 keystore.
    * @param {string} [password] The password of the v3 keystore.
    * @return {string} The address of the newly added account.
@@ -306,7 +306,7 @@ export default class Wallet {
   }
 
   /**
-   * Saves the accounts in the wallet as V3 Keystores, locking them with the password.
+   * Saves the accounts in the wallet as v3 keystores, locking them with the password.
    * @param {string} password The password.
    * @param {V3KeystoreOptions} options The v3 keystore options.
    * @return {V3Keystore[]} The v3 keystores.


### PR DESCRIPTION
Change summary:
- Add more typedoc comments to layer 1 classes, types, and interfaces
- Remove some deprecated source files
- Comment out the typedoc comments of some hidden source code
- Rename EventChannelConnectionOptions

Related issues:
- https://github.com/ainblockchain/ain-blockchain/issues/1207