### PR TITLE
Add typedoc comments for event manager modules

### DIFF
--- a/src/event-manager/event-callback-manager.ts
+++ b/src/event-manager/event-callback-manager.ts
@@ -1,6 +1,6 @@
 import EventFilter from './event-filter';
 import Subscription from './subscription';
-import { BlockchainEventTypes, EventConfigType, BlockchainEventCallback, FilterDeletedEventCallback, FilterDeletedEvent } from '../types';
+import { BlockchainEventTypes, BlockchainEventConfig, BlockchainEventCallback, FilterDeletedEventCallback, FilterDeletedEvent } from '../types';
 import { PushId } from '../ain-db/push-id';
 import { FAILED_TO_REGISTER_ERROR_CODE } from '../constants';
 
@@ -47,7 +47,7 @@ export default class EventCallbackManager {
     });
   }
 
-  createFilter(eventTypeStr: string, config: EventConfigType): EventFilter {
+  createFilter(eventTypeStr: string, config: BlockchainEventConfig): EventFilter {
     const eventType = eventTypeStr as BlockchainEventTypes;
     if (!Object.values(BlockchainEventTypes).includes(eventType) ||
         eventType === BlockchainEventTypes.FILTER_DELETED) {

--- a/src/event-manager/event-callback-manager.ts
+++ b/src/event-manager/event-callback-manager.ts
@@ -1,6 +1,6 @@
 import EventFilter from './event-filter';
 import Subscription from './subscription';
-import { BlockchainEventTypes, BlockchainEventConfig, BlockchainEventCallback, FilterDeletedEventCallback, FilterDeletedEvent } from '../types';
+import { BlockchainEventTypes, BlockchainEventConfig, BlockchainEventCallback, BlockchainErrorCallback, FilterDeletedEventCallback, FilterDeletedEvent } from '../types';
 import { PushId } from '../ain-db/push-id';
 import { FAILED_TO_REGISTER_ERROR_CODE } from '../constants';
 
@@ -113,14 +113,14 @@ export default class EventCallbackManager {
    * Creates a new Subscription object.
    * @param {EventFilter} filter The event filter.
    * @param {BlockchainEventCallback} eventCallback The blockchain event callback function.
-   * @param {(error: any) => void} errorCallback The error callback function.
+   * @param {BlockchainErrorCallback} errorCallback The blockchain error callback function.
    * @param {FilterDeletedEventCallback} filterDeletedEventCallback The filter deletion event callback function.
    * @returns {Subscription} The subscription object created.
    */
   createSubscription(
     filter: EventFilter,
     eventCallback?: BlockchainEventCallback,
-    errorCallback?: (error: any) => void,
+    errorCallback?: BlockchainErrorCallback,
     filterDeletedEventCallback: FilterDeletedEventCallback = (payload) => console.log(
         `Event filter (id: ${payload.filter_id}) is deleted because of ${payload.reason}`)
   ): Subscription {

--- a/src/event-manager/event-callback-manager.ts
+++ b/src/event-manager/event-callback-manager.ts
@@ -4,23 +4,45 @@ import { BlockchainEventTypes, BlockchainEventConfig, BlockchainEventCallback, F
 import { PushId } from '../ain-db/push-id';
 import { FAILED_TO_REGISTER_ERROR_CODE } from '../constants';
 
+/**
+ * A class for managing event callbacks.
+ */
 export default class EventCallbackManager {
+  /** The event filter map from filter ID to event filter. */
   private readonly _filters: Map<string, EventFilter>;
+  /** The subscription map from filter ID to subscription. */
   private readonly _filterIdToSubscription: Map<string, Subscription>;
 
+  /**
+   * Creates a new EventCallbackManager object.
+   */
   constructor() {
     this._filters = new Map<string, EventFilter>();
     this._filterIdToSubscription = new Map<string, Subscription>();
   }
 
+  /**
+   * Builds a filter ID.
+   * @returns {string} The filter ID built.
+   */
   buildFilterId() {
     return PushId.generate();
   }
 
+  /**
+   * Builds a subscription ID.
+   * @returns {string} The subscription ID built.
+   */
   buildSubscriptionId() {
     return PushId.generate();
   }
 
+  /**
+   * Emits a blockchain event to trigger callback functions.
+   * @param {string} filterId The filter ID.
+   * @param {BlockchainEventTypes} eventType The blockchain event type.
+   * @param {any} payload The payload of the event.
+   */
   emitEvent(filterId: string, eventType: BlockchainEventTypes, payload: any) {
     const subscription = this._filterIdToSubscription.get(filterId);
     if (!subscription) {
@@ -33,6 +55,12 @@ export default class EventCallbackManager {
     subscription.emit('event', payload);
   }
 
+  /**
+   * Emits an error to trigger callback functions.
+   * @param {string} filterId The filter ID.
+   * @param {number} code The error code.
+   * @param {string} errorMessage The error message.
+   */
   emitError(filterId: string, code: number, errorMessage: string) {
     const subscription = this._filterIdToSubscription.get(filterId);
     if (!subscription) {
@@ -47,6 +75,12 @@ export default class EventCallbackManager {
     });
   }
 
+  /**
+   * Creates a new EventFilter object and adds it to the event filter map.
+   * @param {string} eventTypeStr The event type string.
+   * @param {BlockchainEventConfig} config The blockchain event configuration.
+   * @returns {EventFilter} The event filter object created.
+   */
   createFilter(eventTypeStr: string, config: BlockchainEventConfig): EventFilter {
     const eventType = eventTypeStr as BlockchainEventTypes;
     if (!Object.values(BlockchainEventTypes).includes(eventType) ||
@@ -62,7 +96,12 @@ export default class EventCallbackManager {
     return filter;
   }
 
-  getFilter(filterId): EventFilter {
+  /**
+   * Looks up an event filter with a filter ID.
+   * @param {string} filterId The filter ID.
+   * @returns {EventFilter} The event filter looked up.
+   */
+  getFilter(filterId: string): EventFilter {
     const filter = this._filters.get(filterId);
     if (!filter) {
       throw Error(`Non-existent filter ID (${filterId})`);
@@ -70,13 +109,21 @@ export default class EventCallbackManager {
     return filter;
   }
 
+  /**
+   * Creates a new Subscription object.
+   * @param {EventFilter} filter The event filter.
+   * @param {BlockchainEventCallback} eventCallback The blockchain event callback function.
+   * @param {(error: any) => void} errorCallback The error callback function.
+   * @param {FilterDeletedEventCallback} filterDeletedEventCallback The filter deletion event callback function.
+   * @returns {Subscription} The subscription object created.
+   */
   createSubscription(
     filter: EventFilter,
     eventCallback?: BlockchainEventCallback,
     errorCallback?: (error: any) => void,
     filterDeletedEventCallback: FilterDeletedEventCallback = (payload) => console.log(
         `Event filter (id: ${payload.filter_id}) is deleted because of ${payload.reason}`)
-  ) {
+  ): Subscription {
     const subscription = new Subscription(filter);
     subscription.on(
       'filterDeleted', (payload: FilterDeletedEvent) => {
@@ -94,6 +141,10 @@ export default class EventCallbackManager {
     return subscription;
   }
 
+  /**
+   * Deletes an event filter.
+   * @param {string} filterId The event filter ID to delete.
+   */
   deleteFilter(filterId: string) {
     if (!this._filterIdToSubscription.delete(filterId)) {
       console.log(`Can't remove the subscription because it can't be found. (${filterId})`);

--- a/src/event-manager/event-channel-client.ts
+++ b/src/event-manager/event-channel-client.ts
@@ -49,12 +49,12 @@ export default class EventChannelClient {
   }
 
   /**
-   * Opens an event channel.
+   * Opens a new event channel.
    * @param {EventChannelConnectionOptions} connectionOption The event channel connection options.
    * @param {DisconnectionCallback} disconnectionCallback The disconnection callback function.
    * @returns {Promise<void>} A promise for the connection success.
    */
-  connect(connectionOption: EventChannelConnectionOptions, disconnectionCallback?: DisconnectionCallback) {
+  connect(connectionOption: EventChannelConnectionOptions, disconnectionCallback?: DisconnectionCallback): Promise<any> {
     return new Promise(async (resolve, reject) => {
       if (this.isConnected) {
         reject(new Error(`Can't connect multiple channels`));
@@ -114,7 +114,7 @@ export default class EventChannelClient {
   }
 
   /**
-   * Closes the event channel.
+   * Closes the current event channel.
    */
   disconnect() {
     this._isConnected = false;

--- a/src/event-manager/event-channel-client.ts
+++ b/src/event-manager/event-channel-client.ts
@@ -5,7 +5,7 @@ import {
   EventChannelMessage,
   BlockchainEventTypes,
   EventChannelConnectionOptions,
-  DisconnectCallback,
+  DisconnectionCallback,
 } from '../types';
 import EventFilter from './event-filter';
 import EventCallbackManager from './event-callback-manager';
@@ -34,7 +34,7 @@ export default class EventChannelClient {
     return this._isConnected;
   }
 
-  connect(connectionOption: EventChannelConnectionOptions, disconnectCallback?: DisconnectCallback) {
+  connect(connectionOption: EventChannelConnectionOptions, disconnectionCallback?: DisconnectionCallback) {
     return new Promise(async (resolve, reject) => {
       if (this.isConnected) {
         reject(new Error(`Can't connect multiple channels`));
@@ -86,8 +86,8 @@ export default class EventChannelClient {
       });
       this._wsClient.on('close', () => {
         this.disconnect();
-        if (disconnectCallback) {
-          disconnectCallback(this._wsClient);
+        if (disconnectionCallback) {
+          disconnectionCallback(this._wsClient);
         }
       });
     })

--- a/src/event-manager/event-filter.ts
+++ b/src/event-manager/event-filter.ts
@@ -1,16 +1,32 @@
 import { BlockchainEventTypes, BlockchainEventConfig } from '../types';
 
+/**
+ * A class for filtering blockchain events.
+ */
 export default class EventFilter {
+  /** The event filter ID. */
   public readonly id: string;
+  /** The blockchain event type. */
   public readonly type: BlockchainEventTypes;
+  /** The blockchain event configuration. */
   public readonly config: BlockchainEventConfig;
 
+  /**
+   * Creates a new EventFilter object.
+   * @param {string} id The event filter ID object.
+   * @param {BlockchainEventTypes} type The blockchain event type value.
+   * @param {BlockchainEventConfig} config The blockchain event configuration object.
+   */
   constructor(id: string, type: BlockchainEventTypes, config: BlockchainEventConfig) {
     this.id = id;
     this.type = type;
     this.config = config;
   }
 
+  /**
+   * Converts to a javascript object.
+   * @returns {Object} The javascript object.
+   */
   toObject() {
     return {
       id: this.id,

--- a/src/event-manager/event-filter.ts
+++ b/src/event-manager/event-filter.ts
@@ -1,11 +1,11 @@
-import { BlockchainEventTypes, EventConfigType } from '../types';
+import { BlockchainEventTypes, BlockchainEventConfig } from '../types';
 
 export default class EventFilter {
   public readonly id: string;
   public readonly type: BlockchainEventTypes;
-  public readonly config: EventConfigType;
+  public readonly config: BlockchainEventConfig;
 
-  constructor(id: string, type: BlockchainEventTypes, config: EventConfigType) {
+  constructor(id: string, type: BlockchainEventTypes, config: BlockchainEventConfig) {
     this.id = id;
     this.type = type;
     this.config = config;

--- a/src/event-manager/index.ts
+++ b/src/event-manager/index.ts
@@ -3,7 +3,7 @@ import {
   BlockFinalizedEventConfig, BlockFinalizedEvent,
   ErrorFirstCallback,
   EventChannelConnectionOptions,
-  EventConfigType, BlockchainEventCallback,
+  BlockchainEventConfig, BlockchainEventCallback,
   TxStateChangedEventConfig, TxStateChangedEvent,
   ValueChangedEventConfig, ValueChangedEvent, DisconnectCallback, FilterDeletedEventCallback,
 } from '../types';
@@ -51,7 +51,7 @@ export default class EventManager {
   ): string;
   subscribe(
     eventTypeStr: string,
-    config: EventConfigType,
+    config: BlockchainEventConfig,
     eventCallback?: BlockchainEventCallback,
     errorCallback?: (error: any) => void,
     filterDeletedEventCallback?: FilterDeletedEventCallback

--- a/src/event-manager/index.ts
+++ b/src/event-manager/index.ts
@@ -5,7 +5,7 @@ import {
   EventChannelConnectionOptions,
   BlockchainEventConfig, BlockchainEventCallback,
   TxStateChangedEventConfig, TxStateChangedEvent,
-  ValueChangedEventConfig, ValueChangedEvent, DisconnectCallback, FilterDeletedEventCallback,
+  ValueChangedEventConfig, ValueChangedEvent, DisconnectionCallback, FilterDeletedEventCallback,
 } from '../types';
 import EventChannelClient from './event-channel-client';
 import EventCallbackManager from './event-callback-manager';
@@ -22,8 +22,8 @@ export default class EventManager {
     this._eventChannelClient = new EventChannelClient(ain, this._eventCallbackManager);
   }
 
-  async connect(connectionOption?: EventChannelConnectionOptions, disconnectCallback?: DisconnectCallback) {
-    await this._eventChannelClient.connect(connectionOption || {}, disconnectCallback);
+  async connect(connectionOption?: EventChannelConnectionOptions, disconnectionCallback?: DisconnectionCallback) {
+    await this._eventChannelClient.connect(connectionOption || {}, disconnectionCallback);
   }
 
   disconnect() {

--- a/src/event-manager/index.ts
+++ b/src/event-manager/index.ts
@@ -5,7 +5,7 @@ import {
   EventChannelConnectionOptions,
   BlockchainEventConfig, BlockchainEventCallback,
   TxStateChangedEventConfig, TxStateChangedEvent,
-  ValueChangedEventConfig, ValueChangedEvent, DisconnectionCallback, FilterDeletedEventCallback,
+  ValueChangedEventConfig, ValueChangedEvent, DisconnectionCallback, FilterDeletedEventCallback, BlockchainErrorCallback,
 } from '../types';
 import EventChannelClient from './event-channel-client';
 import EventCallbackManager from './event-callback-manager';
@@ -49,19 +49,19 @@ export default class EventManager {
     eventType: 'BLOCK_FINALIZED',
     config: BlockFinalizedEventConfig,
     eventCallback?: (event: BlockFinalizedEvent) => void,
-    errorCallback?: (error: any) => void
+    errorCallback?: BlockchainErrorCallback
   ): string;
   subscribe(
     eventType: 'VALUE_CHANGED',
     config: ValueChangedEventConfig,
     eventCallback?: (event: ValueChangedEvent) => void,
-    errorCallback?: (error: any) => void
+    errorCallback?: BlockchainErrorCallback
   ): string;
   subscribe(
     eventType: 'TX_STATE_CHANGED',
     config: TxStateChangedEventConfig,
     eventCallback?: (event: TxStateChangedEvent) => void,
-    errorCallback?: (error: any) => void,
+    errorCallback?: BlockchainErrorCallback,
     filterDeletedEventCallback?: FilterDeletedEventCallback
   ): string;
   /**
@@ -69,15 +69,15 @@ export default class EventManager {
    * @param {string} eventTypeStr The event type.
    * @param {BlockchainEventConfig} config The blockchain event configuraiton.
    * @param {BlockchainEventCallback} eventCallback The blockchain event callback function.
-   * @param {(error: any) => void} errorCallback The error event callback function.
-   * @param {FilterDeletedEventCallback} errorCallback The filter-deleted event callback function.
+   * @param {BlockchainErrorCallback} errorCallback The blockchain error callback function.
+   * @param {FilterDeletedEventCallback} filterDeletedEventCallback The filter-deleted event callback function.
    * @returns {string} The created filter ID.
    */
   subscribe(
     eventTypeStr: string,
     config: BlockchainEventConfig,
     eventCallback?: BlockchainEventCallback,
-    errorCallback?: (error: any) => void,
+    errorCallback?: BlockchainErrorCallback,
     filterDeletedEventCallback?: FilterDeletedEventCallback
   ): string {
     if (!this._eventChannelClient.isConnected) {

--- a/src/event-manager/index.ts
+++ b/src/event-manager/index.ts
@@ -11,21 +11,36 @@ import EventChannelClient from './event-channel-client';
 import EventCallbackManager from './event-callback-manager';
 import EventFilter from './event-filter';
 
+/**
+ * A class for managing blockchain events.
+ */
 export default class EventManager {
-  private _ain: Ain;
+  /** The event callback manager. */
   private readonly _eventCallbackManager: EventCallbackManager;
+  /** The event channel client. */
   private readonly _eventChannelClient: EventChannelClient;
 
+  /**
+   * Creates a new EventManager object.
+   * @param {Ain} ain The Ain object.
+   */
   constructor(ain: Ain) {
-    this._ain = ain;
     this._eventCallbackManager = new EventCallbackManager();
     this._eventChannelClient = new EventChannelClient(ain, this._eventCallbackManager);
   }
 
+  /**
+   * Opens a new event channel.
+   * @param {EventChannelConnectionOptions} connectionOption The event channel connection options.
+   * @param {DisconnectionCallback} disconnectionCallback The disconnection callback function.
+   */
   async connect(connectionOption?: EventChannelConnectionOptions, disconnectionCallback?: DisconnectionCallback) {
     await this._eventChannelClient.connect(connectionOption || {}, disconnectionCallback);
   }
 
+  /**
+   * Closes the current event channel.
+   */
   disconnect() {
     this._eventChannelClient.disconnect();
   }
@@ -49,6 +64,15 @@ export default class EventManager {
     errorCallback?: (error: any) => void,
     filterDeletedEventCallback?: FilterDeletedEventCallback
   ): string;
+  /**
+   * Subscribes to blockchain events.
+   * @param {string} eventTypeStr The event type.
+   * @param {BlockchainEventConfig} config The blockchain event configuraiton.
+   * @param {BlockchainEventCallback} eventCallback The blockchain event callback function.
+   * @param {(error: any) => void} errorCallback The error event callback function.
+   * @param {FilterDeletedEventCallback} errorCallback The filter-deleted event callback function.
+   * @returns {string} The created filter ID.
+   */
   subscribe(
     eventTypeStr: string,
     config: BlockchainEventConfig,
@@ -65,6 +89,11 @@ export default class EventManager {
     return filter.id;
   }
 
+  /**
+   * Cancel a subscription.
+   * @param {string} filterId The filter ID of the subscription to cancel.
+   * @param {ErrorFirstCallback} callback The error handling callback function.
+   */
   unsubscribe(filterId: string, callback: ErrorFirstCallback<EventFilter>) {
     try {
       if (!this._eventChannelClient.isConnected) {

--- a/src/event-manager/subscription.ts
+++ b/src/event-manager/subscription.ts
@@ -2,7 +2,7 @@ import { EventEmitter } from 'events';
 import EventFilter from './event-filter';
 
 /**
- * A class for subscribing to blockchain events based on EventEmitter class.
+ * A class for subscribing callback functions to blockchain events.
  */
 export default class Subscription extends EventEmitter {
   /** The event filter object. */

--- a/src/event-manager/subscription.ts
+++ b/src/event-manager/subscription.ts
@@ -1,14 +1,25 @@
 import { EventEmitter } from 'events';
 import EventFilter from './event-filter';
 
+/**
+ * A class for subscribing to blockchain events based on EventEmitter class.
+ */
 export default class Subscription extends EventEmitter {
+  /** The event filter object. */
   private readonly _filter: EventFilter;
 
+  /**
+   * Creates a new Subscription object.
+   * @param {EventFilter} filter The event filter object.
+   */
   constructor(filter: EventFilter) {
     super();
     this._filter = filter;
   }
 
+  /**
+   * Getter for the event filter.
+   */
   get filter(): EventFilter {
     return this._filter;
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -381,7 +381,7 @@ export interface TxStateChangedEventConfig {
 }
 
 /**
- * A type for event configuration (blockchain event handler).
+ * A type for blockchain event configuration (blockchain event handler).
  */
 export type BlockchainEventConfig = BlockFinalizedEventConfig | ValueChangedEventConfig | TxStateChangedEventConfig;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -483,6 +483,11 @@ export interface BlockchainEventCallback {
 }
 
 /**
+ * A type for blockchain error callback functions (blockchain event handler).
+ */
+export type BlockchainErrorCallback = (error: any) => void;
+
+/**
  * A type for filter-deleted event callback functions (blockchain event handler).
  */
 export type FilterDeletedEventCallback = (event: FilterDeletedEvent) => void;

--- a/src/types.ts
+++ b/src/types.ts
@@ -383,7 +383,7 @@ export interface TxStateChangedEventConfig {
 /**
  * A type for event configuration (blockchain event handler).
  */
-export type EventConfigType = BlockFinalizedEventConfig | ValueChangedEventConfig | TxStateChangedEventConfig;
+export type BlockchainEventConfig = BlockFinalizedEventConfig | ValueChangedEventConfig | TxStateChangedEventConfig;
 
 /**
  * An interface for event-channel-connection options (blockchain event handler).

--- a/src/types.ts
+++ b/src/types.ts
@@ -474,7 +474,7 @@ export interface FilterDeletedEvent {
 }
 
 /**
- * An interface for blockchain event callback (blockchain event handler).
+ * An interface for blockchain event callback functions (blockchain event handler).
  */
 export interface BlockchainEventCallback {
   (event: BlockFinalizedEvent): void;
@@ -483,11 +483,11 @@ export interface BlockchainEventCallback {
 }
 
 /**
- * A type for filter-deleted event callback (blockchain event handler).
+ * A type for filter-deleted event callback functions (blockchain event handler).
  */
 export type FilterDeletedEventCallback = (event: FilterDeletedEvent) => void;
 
 /**
- * A type for disconnected callback (blockchain event handler).
+ * A type for disconnection callback functions (blockchain event handler).
  */
-export type DisconnectCallback = (webSocket) => void;
+export type DisconnectionCallback = (webSocket) => void;


### PR DESCRIPTION
Change summary:
- Add typedoc comments for event manager (event handler) modules
- Rename: EventConfigType -> BlockchainEventConfig
- Rename: DisconnectCallback -> DisconnectionCallback
- Remove some unused member variables

Related issues:
- https://github.com/ainblockchain/ain-blockchain/issues/1207