### PR TITLE
Allow up to 6 decimals in transfer values

### DIFF
--- a/__tests__/ain.test.ts
+++ b/__tests__/ain.test.ts
@@ -75,54 +75,56 @@ describe('ain-js', function() {
 
   describe('Wallet', function() {
     it('countDecimals', function() {
-      expect(Wallet.countDecimals(0)).toBe(0);
-      expect(Wallet.countDecimals(1)).toBe(0);
-      expect(Wallet.countDecimals(10)).toBe(0);
-      expect(Wallet.countDecimals(100)).toBe(0);
-      expect(Wallet.countDecimals(1000)).toBe(0);
-      expect(Wallet.countDecimals(10000)).toBe(0);
-      expect(Wallet.countDecimals(100000)).toBe(0);
-      expect(Wallet.countDecimals(1000000)).toBe(0);
-      expect(Wallet.countDecimals(10000000)).toBe(0);
-      expect(Wallet.countDecimals(100000000)).toBe(0);
-      expect(Wallet.countDecimals(123456789)).toBe(0);
-      expect(Wallet.countDecimals(11)).toBe(0);
-      expect(Wallet.countDecimals(101)).toBe(0);
-      expect(Wallet.countDecimals(1001)).toBe(0);
-      expect(Wallet.countDecimals(10001)).toBe(0);
-      expect(Wallet.countDecimals(100001)).toBe(0);
-      expect(Wallet.countDecimals(1000001)).toBe(0);
-      expect(Wallet.countDecimals(10000001)).toBe(0);
-      expect(Wallet.countDecimals(100000001)).toBe(0);
-      expect(Wallet.countDecimals(1)).toBe(0);
-      expect(Wallet.countDecimals(0.1)).toBe(1);
-      expect(Wallet.countDecimals(0.01)).toBe(2);
-      expect(Wallet.countDecimals(0.001)).toBe(3);
-      expect(Wallet.countDecimals(0.0001)).toBe(4);
-      expect(Wallet.countDecimals(0.00001)).toBe(5);
-      expect(Wallet.countDecimals(0.000001)).toBe(6);
-      expect(Wallet.countDecimals(0.0000001)).toBe(7);
-      expect(Wallet.countDecimals(0.00000001)).toBe(8);
-      expect(Wallet.countDecimals(0.000000001)).toBe(9);
-      expect(Wallet.countDecimals(1.2)).toBe(1);
-      expect(Wallet.countDecimals(0.12)).toBe(2);
-      expect(Wallet.countDecimals(0.012)).toBe(3);
-      expect(Wallet.countDecimals(0.0012)).toBe(4);
-      expect(Wallet.countDecimals(0.00012)).toBe(5);
-      expect(Wallet.countDecimals(0.000012)).toBe(6);
-      expect(Wallet.countDecimals(0.0000012)).toBe(7);
-      expect(Wallet.countDecimals(0.00000012)).toBe(8);
-      expect(Wallet.countDecimals(0.000000012)).toBe(9);
-      expect(Wallet.countDecimals(0.0000000012)).toBe(10);
-      expect(Wallet.countDecimals(1.03)).toBe(2);
-      expect(Wallet.countDecimals(1.003)).toBe(3);
-      expect(Wallet.countDecimals(1.0003)).toBe(4);
-      expect(Wallet.countDecimals(1.00003)).toBe(5);
-      expect(Wallet.countDecimals(1.000003)).toBe(6);
-      expect(Wallet.countDecimals(1.0000003)).toBe(7);
-      expect(Wallet.countDecimals(1.00000003)).toBe(8);
-      expect(Wallet.countDecimals(1.000000003)).toBe(9);
-      expect(Wallet.countDecimals(1.0000000003)).toBe(10);
+      expect(Wallet.countDecimals(0)).toBe(0);  // '0'
+      expect(Wallet.countDecimals(1)).toBe(0);  // '1'
+      expect(Wallet.countDecimals(10)).toBe(0);  // '10'
+      expect(Wallet.countDecimals(100)).toBe(0);  // '100'
+      expect(Wallet.countDecimals(1000)).toBe(0);  // '1000'
+      expect(Wallet.countDecimals(10000)).toBe(0);  // '10000'
+      expect(Wallet.countDecimals(100000)).toBe(0);  // '100000'
+      expect(Wallet.countDecimals(1000000)).toBe(0);  // '1000000'
+      expect(Wallet.countDecimals(10000000)).toBe(0);  // '10000000'
+      expect(Wallet.countDecimals(100000000)).toBe(0);  // '100000000'
+      expect(Wallet.countDecimals(1000000000)).toBe(0);  // '1000000000'
+      expect(Wallet.countDecimals(1234567890)).toBe(0);  // '1234567890'
+      expect(Wallet.countDecimals(11)).toBe(0);  // '11'
+      expect(Wallet.countDecimals(101)).toBe(0);  // '101'
+      expect(Wallet.countDecimals(1001)).toBe(0);  // '1001'
+      expect(Wallet.countDecimals(10001)).toBe(0);  // '10001'
+      expect(Wallet.countDecimals(100001)).toBe(0);  // '100001'
+      expect(Wallet.countDecimals(1000001)).toBe(0);  // '1000001'
+      expect(Wallet.countDecimals(10000001)).toBe(0);  // '10000001'
+      expect(Wallet.countDecimals(100000001)).toBe(0);  // '100000001'
+      expect(Wallet.countDecimals(1000000001)).toBe(0);  // '1000000001'
+      expect(Wallet.countDecimals(0.1)).toBe(1);  // '0.1'
+      expect(Wallet.countDecimals(0.01)).toBe(2);  // '0.01'
+      expect(Wallet.countDecimals(0.001)).toBe(3);  // '0.001'
+      expect(Wallet.countDecimals(0.0001)).toBe(4);  // '0.0001'
+      expect(Wallet.countDecimals(0.00001)).toBe(5);  // '0.00001'
+      expect(Wallet.countDecimals(0.000001)).toBe(6);  // '0.000001'
+      expect(Wallet.countDecimals(0.0000001)).toBe(7);  // '1e-7'
+      expect(Wallet.countDecimals(0.00000001)).toBe(8);  // '1e-8'
+      expect(Wallet.countDecimals(0.000000001)).toBe(9);  // '1e-9'
+      expect(Wallet.countDecimals(0.0000000001)).toBe(10);  // '1e-10'
+      expect(Wallet.countDecimals(1.2)).toBe(1);  // '1.2'
+      expect(Wallet.countDecimals(0.12)).toBe(2);  // '0.12'
+      expect(Wallet.countDecimals(0.012)).toBe(3);  // '0.012'
+      expect(Wallet.countDecimals(0.0012)).toBe(4);  // '0.0012'
+      expect(Wallet.countDecimals(0.00012)).toBe(5);  // '0.00012'
+      expect(Wallet.countDecimals(0.000012)).toBe(6);  // '0.000012'
+      expect(Wallet.countDecimals(0.0000012)).toBe(7);  // '0.0000012'
+      expect(Wallet.countDecimals(0.00000012)).toBe(8);  // '1.2e-7'
+      expect(Wallet.countDecimals(0.000000012)).toBe(9);  // '1.2e-8'
+      expect(Wallet.countDecimals(0.0000000012)).toBe(10);  // '1.2e-9'
+      expect(Wallet.countDecimals(1.03)).toBe(2);  // '1.03'
+      expect(Wallet.countDecimals(1.003)).toBe(3);  // '1.003'
+      expect(Wallet.countDecimals(1.0003)).toBe(4);  // '1.0003'
+      expect(Wallet.countDecimals(1.00003)).toBe(5);  // '1.00003'
+      expect(Wallet.countDecimals(1.000003)).toBe(6);  // '1.000003'
+      expect(Wallet.countDecimals(1.0000003)).toBe(7);  // '1.0000003'
+      expect(Wallet.countDecimals(1.00000003)).toBe(8);  // '1.00000003'
+      expect(Wallet.countDecimals(1.000000003)).toBe(9);  // '1.000000003'
+      expect(Wallet.countDecimals(1.0000000003)).toBe(10);  // '1.0000000003'
     });
 
     it('create', function() {

--- a/__tests__/ain.test.ts
+++ b/__tests__/ain.test.ts
@@ -1,5 +1,6 @@
 // @ts-nocheck
 import Ain from '../src/ain';
+import Wallet from '../src/wallet';
 import { TransactionBody, SetOperation, TransactionInput } from '../src/types';
 import axios from 'axios';
 import { fail, eraseProtoVer } from './test_util';
@@ -73,7 +74,57 @@ describe('ain-js', function() {
   });
 
   describe('Wallet', function() {
-    let addresses = []
+    it('countDecimals', function() {
+      expect(Wallet.countDecimals(0)).toBe(0);
+      expect(Wallet.countDecimals(1)).toBe(0);
+      expect(Wallet.countDecimals(10)).toBe(0);
+      expect(Wallet.countDecimals(100)).toBe(0);
+      expect(Wallet.countDecimals(1000)).toBe(0);
+      expect(Wallet.countDecimals(10000)).toBe(0);
+      expect(Wallet.countDecimals(100000)).toBe(0);
+      expect(Wallet.countDecimals(1000000)).toBe(0);
+      expect(Wallet.countDecimals(10000000)).toBe(0);
+      expect(Wallet.countDecimals(100000000)).toBe(0);
+      expect(Wallet.countDecimals(123456789)).toBe(0);
+      expect(Wallet.countDecimals(11)).toBe(0);
+      expect(Wallet.countDecimals(101)).toBe(0);
+      expect(Wallet.countDecimals(1001)).toBe(0);
+      expect(Wallet.countDecimals(10001)).toBe(0);
+      expect(Wallet.countDecimals(100001)).toBe(0);
+      expect(Wallet.countDecimals(1000001)).toBe(0);
+      expect(Wallet.countDecimals(10000001)).toBe(0);
+      expect(Wallet.countDecimals(100000001)).toBe(0);
+      expect(Wallet.countDecimals(1)).toBe(0);
+      expect(Wallet.countDecimals(0.1)).toBe(1);
+      expect(Wallet.countDecimals(0.01)).toBe(2);
+      expect(Wallet.countDecimals(0.001)).toBe(3);
+      expect(Wallet.countDecimals(0.0001)).toBe(4);
+      expect(Wallet.countDecimals(0.00001)).toBe(5);
+      expect(Wallet.countDecimals(0.000001)).toBe(6);
+      expect(Wallet.countDecimals(0.0000001)).toBe(7);
+      expect(Wallet.countDecimals(0.00000001)).toBe(8);
+      expect(Wallet.countDecimals(0.000000001)).toBe(9);
+      expect(Wallet.countDecimals(1.2)).toBe(1);
+      expect(Wallet.countDecimals(0.12)).toBe(2);
+      expect(Wallet.countDecimals(0.012)).toBe(3);
+      expect(Wallet.countDecimals(0.0012)).toBe(4);
+      expect(Wallet.countDecimals(0.00012)).toBe(5);
+      expect(Wallet.countDecimals(0.000012)).toBe(6);
+      expect(Wallet.countDecimals(0.0000012)).toBe(7);
+      expect(Wallet.countDecimals(0.00000012)).toBe(8);
+      expect(Wallet.countDecimals(0.000000012)).toBe(9);
+      expect(Wallet.countDecimals(0.0000000012)).toBe(10);
+      expect(Wallet.countDecimals(1.03)).toBe(2);
+      expect(Wallet.countDecimals(1.003)).toBe(3);
+      expect(Wallet.countDecimals(1.0003)).toBe(4);
+      expect(Wallet.countDecimals(1.00003)).toBe(5);
+      expect(Wallet.countDecimals(1.000003)).toBe(6);
+      expect(Wallet.countDecimals(1.0000003)).toBe(7);
+      expect(Wallet.countDecimals(1.00000003)).toBe(8);
+      expect(Wallet.countDecimals(1.000000003)).toBe(9);
+      expect(Wallet.countDecimals(1.0000000003)).toBe(10);
+    });
+
     it('create', function() {
       const beforeLength = ain.wallet.length;
       ain.wallet.create(2);

--- a/__tests__/ain.test.ts
+++ b/__tests__/ain.test.ts
@@ -273,6 +273,32 @@ describe('ain-js', function() {
       expect(balanceAfter).toBe(balanceBefore - 100);
     });
 
+    it('transfer with a value of up to 6 decimal places', async function() {
+      const balanceBefore = await ain.wallet.getBalance();
+      const response = await ain.wallet.transfer({
+          to: '0xbA58D93edD8343C001eC5f43E620712Ba8C10813',
+          value: 0.000001,  // of 6 decimal places
+          nonce: -1 });
+      const balanceAfter = await ain.wallet.getBalance();
+      expect(balanceAfter).toBe(balanceBefore - 0.000001);
+    });
+
+    it('transfer with a value of more than 6 decimal places', async function() {
+      const balanceBefore = await ain.wallet.getBalance();
+      try {
+        const response = await ain.wallet.transfer({
+            to: '0xbA58D93edD8343C001eC5f43E620712Ba8C10813',
+            value: 0.0000001,  // of 7 decimal places
+            nonce: -1 });
+        fail('should not happen');
+      } catch(e) {
+        expect(e.message).toBe('Transfer value of more than 6 decimal places.');
+      } finally {
+        const balanceAfter = await ain.wallet.getBalance();
+        expect(balanceAfter).toBe(balanceBefore);
+      }
+    });
+
     it('chainId', function() {
       // chainId = 0
       ain.setProvider(test_node_2, 0);

--- a/src/wallet.ts
+++ b/src/wallet.ts
@@ -3,6 +3,7 @@ import Ain from './ain';
 import { validateMnemonic, mnemonicToSeedSync } from 'bip39';
 import Reference from './ain-db/ref';
 const AIN_HD_DERIVATION_PATH = "m/44'/412'/0'/0/"; /* default wallet address for AIN */
+const MAX_TRANSFERABLE_DECIMALS = 6; /* The maximum transferable decimal places of values */
 
 /**
  * A class for AI Network wallets.
@@ -255,6 +256,10 @@ export default class Wallet {
   transfer(input: {to: string, value: number, from?: string, nonce?: number, gas_price?: number}, isDryrun: boolean = false): Promise<any> {
     const address = this.getImpliedAddress(input.from);
     const toAddress = Ain.utils.toChecksumAddress(input.to);
+    const numDecimalPlaces = Wallet.countDecimals(input.value);
+    if (numDecimalPlaces > MAX_TRANSFERABLE_DECIMALS) {
+      throw Error(`Transfer value of more than ${MAX_TRANSFERABLE_DECIMALS} decimal places.`);
+    }
     const transferRef = this.ain.db.ref(`/transfer/${address}/${toAddress}`).push() as Reference;
     return transferRef.setValue({
         ref: '/value', address, value: input.value, nonce: input.nonce, gas_price: input.gas_price }, isDryrun);

--- a/src/wallet.ts
+++ b/src/wallet.ts
@@ -59,6 +59,25 @@ export default class Wallet {
   }
 
   /**
+   * Counts the given number's decimal number.
+   * @param {number} value
+   * @returns {number} The decimal number.
+   */
+  static countDecimals(value: number): number {
+    const decimalExponentRegex = /(\d*\.{0,1}\d*)e-(\d+)/gm;
+
+    if (Math.floor(value) === value) {
+      return 0;
+    }
+    const valueString = value.toString();
+    const matches = decimalExponentRegex.exec(valueString);
+    if (matches) {
+      return Number(matches[2]) + Wallet.countDecimals(Number(matches[1]));
+    }
+    return valueString.split('.')[1].length || 0; 
+  }
+
+  /**
    * Creates new accounts and adds them to the wallet.
    * @param {number} numberOfAccounts The number of accounts to create.
    * @returns {Array<string>} The newly created accounts.


### PR DESCRIPTION
Change summary:
- Allow up to 6 decimals in transfer values
- Add countDecimals() util function

Related issues:
- https://github.com/ainblockchain/ain-blockchain/issues/1208