### PR TITLE
Add missing account / database methods to ain-js

### DIFF
--- a/__tests__/__snapshots__/ain.test.ts.snap
+++ b/__tests__/__snapshots__/ain.test.ts.snap
@@ -171,6 +171,18 @@ Object {
 
 exports[`ain-js Database getProofHash 1`] = `"0x88496dfee3566db91f487aa4cbf69a0c42a3e2a5d0a65bfd4897d699e8734785"`;
 
+exports[`ain-js Database getStateInfo 1`] = `
+Object {
+  "#num_children": 1,
+  "#state_ph": "0x985a1f057d5047b1dee392127eb776571fbbe79da7ae6114f8f8f18c4f786135",
+  "#tree_bytes": 1840,
+  "#tree_height": 2,
+  "#tree_max_siblings": 1,
+  "#tree_size": 3,
+  "#version": "erased",
+}
+`;
+
 exports[`ain-js Database matchFunction 1`] = `
 Object {
   "matched_config": Object {

--- a/__tests__/ain.test.ts
+++ b/__tests__/ain.test.ts
@@ -267,6 +267,11 @@ describe('ain-js', function() {
       expect(balance).toBeGreaterThan(0);
     });
 
+    it('getNonce', async function() {
+      const nonce = await ain.wallet.getNonce();
+      expect(nonce).toBeNull();
+    });
+
     it('transfer with isDryrun = true', async function() {
       const balanceBefore = await ain.wallet.getBalance();
       const response = await ain.wallet.transfer({

--- a/__tests__/ain.test.ts
+++ b/__tests__/ain.test.ts
@@ -73,6 +73,13 @@ describe('ain-js', function() {
     });
   });
 
+  describe('Provider', function() {
+    it('getAddress', async function() {
+      const address = await ain.provider.getAddress();
+      expect(address).not.toBeNull();
+    });
+  });
+
   describe('Wallet', function() {
     it('countDecimals', function() {
       expect(Wallet.countDecimals(0)).toBe(0);  // '0'

--- a/__tests__/ain.test.ts
+++ b/__tests__/ain.test.ts
@@ -3,7 +3,7 @@ import Ain from '../src/ain';
 import Wallet from '../src/wallet';
 import { TransactionBody, SetOperation, TransactionInput } from '../src/types';
 import axios from 'axios';
-import { fail, eraseProtoVer } from './test_util';
+import { fail, eraseProtoVer, eraseStateVersion } from './test_util';
 const {
   test_keystore,
   test_pw,
@@ -1255,6 +1255,17 @@ describe('ain-js', function() {
       await ain.db.ref('/values/blockchain_params').getProofHash()
       .then(res => {
         expect(res).toMatchSnapshot();
+      })
+      .catch(error => {
+        console.log("error:", error);
+        fail('should not happen');
+      })
+    });
+
+    it('getStateInfo', async function() {
+      await ain.db.ref('/rules/transfer/$from/$to/$key/value').getStateInfo()
+      .then(res => {
+        expect(eraseStateVersion(res)).toMatchSnapshot();
       })
       .catch(error => {
         console.log("error:", error);

--- a/__tests__/ain.test.ts
+++ b/__tests__/ain.test.ts
@@ -269,7 +269,12 @@ describe('ain-js', function() {
 
     it('getNonce', async function() {
       const nonce = await ain.wallet.getNonce();
-      expect(nonce).toBeNull();
+      expect(nonce).toBe(0);
+    });
+
+    it('getTimestamp', async function() {
+      const timestamp = await ain.wallet.getTimestamp();
+      expect(timestamp).toBe(0);
     });
 
     it('transfer with isDryrun = true', async function() {

--- a/__tests__/test_util.ts
+++ b/__tests__/test_util.ts
@@ -1,6 +1,16 @@
+import { set } from 'lodash';
+
 export declare function fail(error?: any): never;
 
-export function eraseProtoVer(retVal) {
-  retVal.protoVer = 'erased';
-  return retVal;
+export function eraseProtoVer(result) {
+  const erased = JSON.parse(JSON.stringify(result));
+  set(erased, 'protoVer', 'erased');
+  return erased;
 }
+
+export function eraseStateVersion(result) {
+  const erased = JSON.parse(JSON.stringify(result));
+  set(erased, '#version', 'erased');
+  return erased;
+}
+

--- a/src/ain-db/ref.ts
+++ b/src/ain-db/ref.ts
@@ -372,6 +372,18 @@ export default class Reference {
     return this._ain.provider.send('ain_getProofHash', request);
   }
 
+  /**
+   * Fetches the state information of a global blockchain state path.
+   * @param {StateInfoInput} params The state info input.
+   * @returns {Promise<any>} The return value of the blockchain API.
+   */
+  getStateInfo(params?: StateInfoInput): Promise<any> {
+    const request = {
+      ref: Reference.extendPath(this.path, params ? params.ref : undefined)
+    }
+    return this._ain.provider.send('ain_getStateInfo', request);
+  }
+
   // TODO(liayoo): Add this function.
   ///**
   // * Attaches an listener for database events.

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -38,6 +38,14 @@ export default class Provider {
   }
 
   /**
+   * Fetches the blockchain node's address.
+   * @returns {Promise<number>} The address value.
+   */
+  getAddress(): Promise<number> {
+    return this.send('ain_getAddress', {})
+  }
+
+  /**
    * Creates a JSON-RPC payload and sends it to the network.
    * @param {string} rpcMethod The JSON-RPC method.
    * @param {any} params The JSON-RPC parameters.

--- a/src/signer/default-signer.ts
+++ b/src/signer/default-signer.ts
@@ -124,31 +124,10 @@ export class DefaultSigner implements Signer {
     }
     let nonce = transactionInput.nonce;
     if (nonce === undefined) {
-      nonce = await this.getNonce({ address, from: "pending" });
+      nonce = await this.wallet.getNonce({ address, from: "pending" });
     }
     const timestamp = transactionInput.timestamp ? transactionInput.timestamp : Date.now();
     const gasPrice = transactionInput.gas_price || 0;
     const billing = transactionInput.billing;
     return Object.assign(tx, { nonce, timestamp, gas_price: gasPrice, billing });
   }
-
-  /**
-   * Fetches an account's nonce value, which is the current transaction count of the account.
-   * @param {object} args The ferch options.
-   * It may contain a string 'address' value and a string 'from' value.
-   * The 'address' is the address of the account to get the nonce of,
-   * and the 'from' is the source of the data.
-   * It could be either the pending transaction pool ("pending") or
-   * the committed blocks ("committed"). The default value is "committed".
-   * @returns {Promise<number>} The nonce value.
-   */
-  getNonce(args: { address?: string, from?: string }): Promise<number> {
-    if (!args) { args = {}; }
-    const address = args.address ? Ain.utils.toChecksumAddress(args.address)
-      : this.getAddress(args.address);
-    if (args.from !== undefined && args.from !== 'pending' && args.from !== 'committed') {
-      throw Error("'from' should be either 'pending' or 'committed'");
-    }
-    return this.provider.send('ain_getNonce', { address, from: args.from })
-  }
-}

--- a/src/signer/default-signer.ts
+++ b/src/signer/default-signer.ts
@@ -131,3 +131,4 @@ export class DefaultSigner implements Signer {
     const billing = transactionInput.billing;
     return Object.assign(tx, { nonce, timestamp, gas_price: gasPrice, billing });
   }
+  };

--- a/src/wallet.ts
+++ b/src/wallet.ts
@@ -249,6 +249,26 @@ export default class Wallet {
   }
 
   /**
+   * Fetches an account's nonce value, which is the current transaction count of the account.
+   * @param {object} args The ferch options.
+   * It may contain a string 'address' value and a string 'from' value.
+   * The 'address' is the address of the account to get the nonce of,
+   * and the 'from' is the source of the data.
+   * It could be either the pending transaction pool ("pending") or
+   * the committed blocks ("committed"). The default value is "committed".
+   * @returns {Promise<number>} The nonce value.
+   */
+  getNonce(args: { address?: string, from?: string }): Promise<number> {
+    if (!args) { args = {}; }
+    const address = args.address ? Ain.utils.toChecksumAddress(args.address)
+      : this.getImpliedAddress(args.address);
+    if (args.from !== undefined && args.from !== 'pending' && args.from !== 'committed') {
+      throw Error("'from' should be either 'pending' or 'committed'");
+    }
+    return this.ain.provider.send('ain_getNonce', { address, from: args.from })
+  }
+
+  /**
    * Sends a transfer transaction to the network.
    * @param {{to: string, value: number, from?: string, nonce?: number, gas_price?: number}} input The input parameters of the transaction.
    * @param {boolean} isDryrun The dryrun option.

--- a/src/wallet.ts
+++ b/src/wallet.ts
@@ -269,6 +269,26 @@ export default class Wallet {
   }
 
   /**
+   * Fetches an account's timestamp value, which is the current transaction count of the account.
+   * @param {object} args The ferch options.
+   * It may contain a string 'address' value and a string 'from' value.
+   * The 'address' is the address of the account to get the timestamp of,
+   * and the 'from' is the source of the data.
+   * It could be either the pending transaction pool ("pending") or
+   * the committed blocks ("committed"). The default value is "committed".
+   * @returns {Promise<number>} The timestamp value.
+   */
+  getTimestamp(args: { address?: string, from?: string }): Promise<number> {
+    if (!args) { args = {}; }
+    const address = args.address ? Ain.utils.toChecksumAddress(args.address)
+      : this.getImpliedAddress(args.address);
+    if (args.from !== undefined && args.from !== 'pending' && args.from !== 'committed') {
+      throw Error("'from' should be either 'pending' or 'committed'");
+    }
+    return this.ain.provider.send('ain_getTimestamp', { address, from: args.from })
+  }
+
+  /**
    * Sends a transfer transaction to the network.
    * @param {{to: string, value: number, from?: string, nonce?: number, gas_price?: number}} input The input parameters of the transaction.
    * @param {boolean} isDryrun The dryrun option.


### PR DESCRIPTION
Change summary:
- Add getStateInfo() method to ref
- Move getNonce() method to wallet from signer
- Add getTimestamp() method to wallet
- Add getAddress() method to provider

Related issues:
- https://github.com/ainblockchain/ain-blockchain/issues/1248 