### PR TITLE
Add missing Block JSON RPC APIs to ain-js

### DIFF
--- a/__tests__/ain.test.ts
+++ b/__tests__/ain.test.ts
@@ -541,6 +541,14 @@ describe('ain-js', function() {
       expect(txCount).not.toBeNull();
     });
 
+    it('getBlockTransactionCountByHash', async function () {
+      const lastBlock= await ain.getLastBlock();
+      expect(lastBlock).not.toBeNull();
+      expect(lastBlock.hash).not.toBeNull();
+      const txCount = await ain.getBlockTransactionCountByHash(lastBlock.hash)
+      expect(txCount).not.toBeNull();
+    });
+
     it('getProposer', async function () {
       const proposer = await ain.getProposer(1);
       const hash = (await ain.getBlockByNumber(1)).hash || "";

--- a/__tests__/ain.test.ts
+++ b/__tests__/ain.test.ts
@@ -533,6 +533,14 @@ describe('ain-js', function() {
       expect(blockList[1].number).toBe(lastBlockNumber);
     });
 
+    it('getBlockTransactionCountByNumber', async function () {
+      const lastBlockNumber = await ain.getLastBlockNumber();
+      expect(lastBlockNumber).not.toBeNull();
+      expect(lastBlockNumber).toBeGreaterThanOrEqual(0);
+      const txCount = await ain.getBlockTransactionCountByNumber(lastBlockNumber)
+      expect(txCount).not.toBeNull();
+    });
+
     it('getProposer', async function () {
       const proposer = await ain.getProposer(1);
       const hash = (await ain.getBlockByNumber(1)).hash || "";

--- a/__tests__/ain.test.ts
+++ b/__tests__/ain.test.ts
@@ -485,6 +485,12 @@ describe('ain-js', function() {
       expect(block.number).not.toBeNull();
     });
 
+    it('getLastBlockNumber', async function () {
+      const number = await ain.getLastBlockNumber()
+      expect(number).not.toBeNull();
+      expect(number).toBeGreaterThan(0);
+    });
+
     it('getBlock', async function () {
       const block = await ain.getBlock(3)
       const hash = block.hash || "";

--- a/__tests__/ain.test.ts
+++ b/__tests__/ain.test.ts
@@ -478,6 +478,13 @@ describe('ain-js', function() {
       await waitUntilTxFinalized(createApps.result.tx_hash);
     });
 
+    it('getLastBlock', async function () {
+      const block = await ain.getLastBlock()
+      expect(block).not.toBeNull();
+      expect(block.hash).not.toBeNull();
+      expect(block.number).not.toBeNull();
+    });
+
     it('getBlock', async function () {
       const block = await ain.getBlock(3)
       const hash = block.hash || "";

--- a/__tests__/ain.test.ts
+++ b/__tests__/ain.test.ts
@@ -522,6 +522,17 @@ describe('ain-js', function() {
       expect(blockList[1].number).toBe(lastBlockNumber);
     });
 
+    it('getBlockHeadersList', async function () {
+      const lastBlockNumber = await ain.getLastBlockNumber();
+      expect(lastBlockNumber).not.toBeNull();
+      expect(lastBlockNumber).toBeGreaterThanOrEqual(0);
+      const blockList = await ain.getBlockHeadersList(lastBlockNumber - 1, lastBlockNumber + 1)
+      expect(blockList).not.toBeNull();
+      expect(blockList.length).toBe(2);
+      expect(blockList[0].number).toBe(lastBlockNumber - 1);
+      expect(blockList[1].number).toBe(lastBlockNumber);
+    });
+
     it('getProposer', async function () {
       const proposer = await ain.getProposer(1);
       const hash = (await ain.getBlockByNumber(1)).hash || "";

--- a/__tests__/ain.test.ts
+++ b/__tests__/ain.test.ts
@@ -492,7 +492,7 @@ describe('ain-js', function() {
     });
 
     it('getBlockByNumber', async function () {
-      const lastBlock = await ain.getLastBlock()
+      const lastBlock = await ain.getLastBlock();
       expect(lastBlock).not.toBeNull();
       expect(lastBlock.number).not.toBeNull();
       const block = await ain.getBlockByNumber(lastBlock.number)
@@ -502,13 +502,24 @@ describe('ain-js', function() {
     });
 
     it('getBlockByHash', async function () {
-      const lastBlock = await ain.getLastBlock()
+      const lastBlock = await ain.getLastBlock();
       expect(lastBlock).not.toBeNull();
       expect(lastBlock.hash).not.toBeNull();
       const block = await ain.getBlockByHash(lastBlock.hash)
       expect(block).not.toBeNull();
       expect(block.number).toBe(lastBlock.number);
       expect(block.hash).toBe(lastBlock.hash);
+    });
+
+    it('getBlockList', async function () {
+      const lastBlockNumber = await ain.getLastBlockNumber();
+      expect(lastBlockNumber).not.toBeNull();
+      expect(lastBlockNumber).toBeGreaterThanOrEqual(0);
+      const blockList = await ain.getBlockList(lastBlockNumber - 1, lastBlockNumber + 1)
+      expect(blockList).not.toBeNull();
+      expect(blockList.length).toBe(2);
+      expect(blockList[0].number).toBe(lastBlockNumber - 1);
+      expect(blockList[1].number).toBe(lastBlockNumber);
     });
 
     it('getProposer', async function () {

--- a/__tests__/ain.test.ts
+++ b/__tests__/ain.test.ts
@@ -482,7 +482,7 @@ describe('ain-js', function() {
       const block = await ain.getLastBlock()
       expect(block).not.toBeNull();
       expect(block.hash).not.toBeNull();
-      expect(block.number).not.toBeNull();
+      expect(block.number).toBeGreaterThan(0);
     });
 
     it('getLastBlockNumber', async function () {
@@ -491,21 +491,35 @@ describe('ain-js', function() {
       expect(number).toBeGreaterThan(0);
     });
 
-    it('getBlock', async function () {
-      const block = await ain.getBlock(3)
-      const hash = block.hash || "";
-      expect(await ain.getBlock(hash)).toStrictEqual(block);
+    it('getBlockByNumber', async function () {
+      const lastBlock = await ain.getLastBlock()
+      expect(lastBlock).not.toBeNull();
+      expect(lastBlock.number).not.toBeNull();
+      const block = await ain.getBlockByNumber(lastBlock.number)
+      expect(block).not.toBeNull();
+      expect(block.number).toBe(lastBlock.number);
+      expect(block.hash).toBe(lastBlock.hash);
+    });
+
+    it('getBlockByHash', async function () {
+      const lastBlock = await ain.getLastBlock()
+      expect(lastBlock).not.toBeNull();
+      expect(lastBlock.hash).not.toBeNull();
+      const block = await ain.getBlockByHash(lastBlock.hash)
+      expect(block).not.toBeNull();
+      expect(block.number).toBe(lastBlock.number);
+      expect(block.hash).toBe(lastBlock.hash);
     });
 
     it('getProposer', async function () {
       const proposer = await ain.getProposer(1);
-      const hash = (await ain.getBlock(1)).hash || "";
+      const hash = (await ain.getBlockByNumber(1)).hash || "";
       expect(await ain.getProposer(hash)).toBe(proposer);
     });
 
     it('getValidators', async function () {
       const validators = await ain.getValidators(4);
-      const hash = (await ain.getBlock(4)).hash || "";
+      const hash = (await ain.getBlockByNumber(4)).hash || "";
       expect(await ain.getValidators(hash)).toStrictEqual(validators);
     });
 
@@ -807,7 +821,7 @@ describe('ain-js', function() {
 
     it('getTransactionByBlockHashAndIndex', async function () {
       const genesisBlockNumber = 0;
-      const genesisBlock = await ain.getBlock(genesisBlockNumber);
+      const genesisBlock = await ain.getBlockByNumber(genesisBlockNumber);
       const tx = await ain.getTransactionByBlockHashAndIndex(genesisBlock.hash, 0);
       expect(tx).not.toBeNull();
     });

--- a/src/ain.ts
+++ b/src/ain.ts
@@ -85,6 +85,14 @@ export default class Ain {
   }
 
   /**
+   * Fetches the last block.
+   * @returns {Promise<Block>}
+   */
+  getLastBlock(): Promise<Block> {
+    return this.provider.send('ain_getLastBlock', {});
+  }
+
+  /**
    * Fetches a block with a block hash or block number.
    * @param {string | number} blockHashOrBlockNumber The block hash or block number.
    * @param {boolean} returnTransactionObjects If it's true, returns a block with full transaction objects.

--- a/src/ain.ts
+++ b/src/ain.ts
@@ -130,7 +130,6 @@ export default class Ain {
    * Fetches blocks with a block number range.
    * @param {number} from The begining block number (inclusive).
    * @param {number} to The ending block number (exclusive).
-   * Otherwise, returns a block with only transaction hashes.
    * @returns {Promise<Array<Block>>}
    */
   getBlockList(from: number, to: number): Promise<Array<Block>> {
@@ -141,11 +140,19 @@ export default class Ain {
    * Fetches block headers with a block number range.
    * @param {number} from The begining block number (inclusive).
    * @param {number} to The ending block number (exclusive).
-   * Otherwise, returns a block with only transaction hashes.
    * @returns {Promise<Array<Block>>}
    */
   getBlockHeadersList(from: number, to: number): Promise<Array<Block>> {
     return this.provider.send('ain_getBlockHeadersList', { from, to });
+  }
+
+  /**
+   * Fetches block transaction count with a block number.
+   * @param {number} number The block number.
+   * @returns {Promise<Number>}
+   */
+  getBlockTransactionCountByNumber(number: number): Promise<Number> {
+    return this.provider.send('ain_getBlockTransactionCountByNumber', { number });
   }
 
   /**

--- a/src/ain.ts
+++ b/src/ain.ts
@@ -138,6 +138,17 @@ export default class Ain {
   }
 
   /**
+   * Fetches block headers with a block number range.
+   * @param {number} from The begining block number (inclusive).
+   * @param {number} to The ending block number (exclusive).
+   * Otherwise, returns a block with only transaction hashes.
+   * @returns {Promise<Array<Block>>}
+   */
+  getBlockHeadersList(from: number, to: number): Promise<Array<Block>> {
+    return this.provider.send('ain_getBlockHeadersList', { from, to });
+  }
+
+  /**
    * Fetches the forger's address of a block with a block hash or block number.
    * @param {string | number} blockHashOrBlockNumber The block hash or block number.
    * @returns {Promise<string>}

--- a/src/ain.ts
+++ b/src/ain.ts
@@ -156,6 +156,15 @@ export default class Ain {
   }
 
   /**
+   * Fetches block transaction count with a block hash.
+   * @param {string} hash The block hash.
+   * @returns {Promise<Number>}
+   */
+  getBlockTransactionCountByHash(hash: string): Promise<Number> {
+    return this.provider.send('ain_getBlockTransactionCountByHash', { hash });
+  }
+
+  /**
    * Fetches the forger's address of a block with a block hash or block number.
    * @param {string | number} blockHashOrBlockNumber The block hash or block number.
    * @returns {Promise<string>}

--- a/src/ain.ts
+++ b/src/ain.ts
@@ -93,6 +93,14 @@ export default class Ain {
   }
 
   /**
+   * Fetches the last block number.
+   * @returns {Promise<Number>}
+   */
+  getLastBlockNumber(): Promise<Block> {
+    return this.provider.send('ain_getLastBlockNumber', {});
+  }
+
+  /**
    * Fetches a block with a block hash or block number.
    * @param {string | number} blockHashOrBlockNumber The block hash or block number.
    * @param {boolean} returnTransactionObjects If it's true, returns a block with full transaction objects.

--- a/src/ain.ts
+++ b/src/ain.ts
@@ -101,19 +101,29 @@ export default class Ain {
   }
 
   /**
-   * Fetches a block with a block hash or block number.
-   * @param {string | number} blockHashOrBlockNumber The block hash or block number.
+   * Fetches a block with a block number.
+   * @param {number} blockNumber The block number.
    * @param {boolean} returnTransactionObjects If it's true, returns a block with full transaction objects.
    * Otherwise, returns a block with only transaction hashes.
    * @returns {Promise<Block>}
    */
-  getBlock(blockHashOrBlockNumber: string | number, returnTransactionObjects?: boolean): Promise<Block> {
-    const byHash = typeof blockHashOrBlockNumber === 'string'
-    const rpcMethod = byHash ? 'ain_getBlockByHash' : 'ain_getBlockByNumber';
-    const data = Object.assign({},
-        { getFullTransactions: !!returnTransactionObjects,
-          [byHash ? 'hash' : 'number']: blockHashOrBlockNumber });
-    return this.provider.send(rpcMethod, data);
+  getBlockByNumber(blockNumber: number, returnTransactionObjects?: boolean): Promise<Block> {
+    const data =
+        Object.assign({}, { getFullTransactions: !!returnTransactionObjects, number: blockNumber });
+    return this.provider.send('ain_getBlockByNumber', data);
+  }
+
+  /**
+   * Fetches a block with a block hash.
+   * @param {string} blockHash The block hash.
+   * @param {boolean} returnTransactionObjects If it's true, returns a block with full transaction objects.
+   * Otherwise, returns a block with only transaction hashes.
+   * @returns {Promise<Block>}
+   */
+  getBlockByHash(blockHash: string, returnTransactionObjects?: boolean): Promise<Block> {
+    const data =
+        Object.assign({}, { getFullTransactions: !!returnTransactionObjects, hash: blockHash });
+    return this.provider.send('ain_getBlockByHash', data);
   }
 
   /**

--- a/src/ain.ts
+++ b/src/ain.ts
@@ -127,6 +127,17 @@ export default class Ain {
   }
 
   /**
+   * Fetches blocks with a block number range.
+   * @param {number} from The begining block number (inclusive).
+   * @param {number} to The ending block number (exclusive).
+   * Otherwise, returns a block with only transaction hashes.
+   * @returns {Promise<Array<Block>>}
+   */
+  getBlockList(from: number, to: number): Promise<Array<Block>> {
+    return this.provider.send('ain_getBlockList', { from, to });
+  }
+
+  /**
    * Fetches the forger's address of a block with a block hash or block number.
    * @param {string | number} blockHashOrBlockNumber The block hash or block number.
    * @returns {Promise<string>}


### PR DESCRIPTION
Change summary:
- Add missing Block JSON RPC APIs to ain-js

Related issues:
- https://github.com/ainblockchain/ain-blockchain/issues/1248