### PR TITLE
Add missing Blockchain Node APIs to ain-js

### DIFF
--- a/__tests__/ain.test.ts
+++ b/__tests__/ain.test.ts
@@ -549,6 +549,22 @@ describe('ain-js', function() {
       expect(txCount).not.toBeNull();
     });
 
+    it('getValidatorsByNumber', async function () {
+      const lastBlock = await ain.getLastBlock();
+      expect(lastBlock).not.toBeNull();
+      expect(lastBlock.number).not.toBeNull();
+      const validators = await ain.getValidatorsByNumber(lastBlock.number);
+      expect(validators).toStrictEqual(lastBlock.validators);
+    });
+
+    it('getValidatorsByHash', async function () {
+      const lastBlock = await ain.getLastBlock();
+      expect(lastBlock).not.toBeNull();
+      expect(lastBlock.number).not.toBeNull();
+      const validators = await ain.getValidatorsByHash(lastBlock.hash);
+      expect(validators).toStrictEqual(lastBlock.validators);
+    });
+
     it('getProposerByNumber', async function () {
       const lastBlock = await ain.getLastBlock();
       expect(lastBlock).not.toBeNull();
@@ -563,12 +579,6 @@ describe('ain-js', function() {
       expect(lastBlock.hash).not.toBeNull();
       const proposer = await ain.getProposerByHash(lastBlock.hash);
       expect(proposer).toBe(lastBlock.proposer);
-    });
-
-    it('getValidators', async function () {
-      const validators = await ain.getValidators(4);
-      const hash = (await ain.getBlockByNumber(4)).hash || "";
-      expect(await ain.getValidators(hash)).toStrictEqual(validators);
     });
 
     // TODO(liayoo): add getTransactionResult method and test case for it.

--- a/__tests__/ain.test.ts
+++ b/__tests__/ain.test.ts
@@ -549,6 +549,14 @@ describe('ain-js', function() {
       expect(txCount).not.toBeNull();
     });
 
+    it('getValidatorInfo', async function () {
+      const lastBlock = await ain.getLastBlock();
+      expect(lastBlock).not.toBeNull();
+      expect(lastBlock.proposer).not.toBeNull();
+      const info = await ain.getValidatorInfo(lastBlock.proposer);
+      expect(info).not.toBeNull();
+    });
+
     it('getValidatorsByNumber', async function () {
       const lastBlock = await ain.getLastBlock();
       expect(lastBlock).not.toBeNull();

--- a/__tests__/ain.test.ts
+++ b/__tests__/ain.test.ts
@@ -549,10 +549,20 @@ describe('ain-js', function() {
       expect(txCount).not.toBeNull();
     });
 
-    it('getProposer', async function () {
-      const proposer = await ain.getProposer(1);
-      const hash = (await ain.getBlockByNumber(1)).hash || "";
-      expect(await ain.getProposer(hash)).toBe(proposer);
+    it('getProposerByNumber', async function () {
+      const lastBlock = await ain.getLastBlock();
+      expect(lastBlock).not.toBeNull();
+      expect(lastBlock.number).not.toBeNull();
+      const proposer = await ain.getProposerByNumber(lastBlock.number);
+      expect(proposer).toBe(lastBlock.proposer);
+    });
+
+    it('getProposerByHash', async function () {
+      const lastBlock = await ain.getLastBlock();
+      expect(lastBlock).not.toBeNull();
+      expect(lastBlock.hash).not.toBeNull();
+      const proposer = await ain.getProposerByHash(lastBlock.hash);
+      expect(proposer).toBe(lastBlock.proposer);
     });
 
     it('getValidators', async function () {

--- a/src/ain.ts
+++ b/src/ain.ts
@@ -165,20 +165,29 @@ export default class Ain {
   }
 
   /**
+   * Fetches the information of the given validator address.
+   * @param {string} address The validator address.
+   * @returns {Promise<any>}
+   */
+  getValidatorInfo(address: string): Promise<any> {
+    return this.provider.send('ain_getValidatorInfo', { address });
+  }
+
+  /**
    * Fetches the validator list of a block with a block number.
    * @param {number} blockNumber The block number.
-   * @returns {Promise<string[]>}
+   * @returns {Promise<any>}
    */
-  getValidatorsByNumber(blockNumber: number): Promise<string[]> {
+  getValidatorsByNumber(blockNumber: number): Promise<any> {
     return this.provider.send('ain_getValidatorsByNumber', { number: blockNumber });
   }
 
   /**
    * Fetches the validator list of a block with a block hash.
    * @param {string} blockHash The block hash.
-   * @returns {Promise<string[]>}
+   * @returns {Promise<any>}
    */
-  getValidatorsByHash(blockHash: string): Promise<string[]> {
+  getValidatorsByHash(blockHash: string): Promise<any> {
     return this.provider.send('ain_getValidatorsByHash', { hash: blockHash });
   }
 

--- a/src/ain.ts
+++ b/src/ain.ts
@@ -165,15 +165,21 @@ export default class Ain {
   }
 
   /**
-   * Fetches the forger's address of a block with a block hash or block number.
-   * @param {string | number} blockHashOrBlockNumber The block hash or block number.
+   * Fetches the forger's address of a block with a block number.
+   * @param {number} blockNumber The block number.
    * @returns {Promise<string>}
    */
-  getProposer(blockHashOrBlockNumber: string | number): Promise<string> {
-    const byHash = typeof blockHashOrBlockNumber === 'string'
-    const rpcMethod = byHash ? 'ain_getProposerByHash' : 'ain_getProposerByNumber';
-    return this.provider.send(rpcMethod,
-        {[byHash ? 'hash' : 'number']: blockHashOrBlockNumber});
+  getProposerByNumber(blockNumber: number): Promise<string> {
+    return this.provider.send('ain_getProposerByNumber', { number: blockNumber });
+  }
+
+  /**
+   * Fetches the forger's address of a block with a block hash.
+   * @param {string} blockHash The block hash.
+   * @returns {Promise<string>}
+   */
+  getProposerByHash(blockHash: string): Promise<string> {
+    return this.provider.send('ain_getProposerByHash', { hash: blockHash });
   }
 
   /**

--- a/src/ain.ts
+++ b/src/ain.ts
@@ -165,6 +165,24 @@ export default class Ain {
   }
 
   /**
+   * Fetches the validator list of a block with a block number.
+   * @param {number} blockNumber The block number.
+   * @returns {Promise<string[]>}
+   */
+  getValidatorsByNumber(blockNumber: number): Promise<string[]> {
+    return this.provider.send('ain_getValidatorsByNumber', { number: blockNumber });
+  }
+
+  /**
+   * Fetches the validator list of a block with a block hash.
+   * @param {string} blockHash The block hash.
+   * @returns {Promise<string[]>}
+   */
+  getValidatorsByHash(blockHash: string): Promise<string[]> {
+    return this.provider.send('ain_getValidatorsByHash', { hash: blockHash });
+  }
+
+  /**
    * Fetches the forger's address of a block with a block number.
    * @param {number} blockNumber The block number.
    * @returns {Promise<string>}
@@ -180,18 +198,6 @@ export default class Ain {
    */
   getProposerByHash(blockHash: string): Promise<string> {
     return this.provider.send('ain_getProposerByHash', { hash: blockHash });
-  }
-
-  /**
-   * Fetches the validator list of a block with a block hash or block number.
-   * @param {string | number} blockHashOrBlockNumber The block hash or block number.
-   * @returns {Promise<string[]>}
-   */
-  getValidators(blockHashOrBlockNumber: string | number): Promise<string[]> {
-    const byHash = typeof blockHashOrBlockNumber === 'string'
-    const rpcMethod = byHash ? 'ain_getValidatorsByHash' : 'ain_getValidatorsByNumber';
-    return this.provider.send(rpcMethod,
-        {[byHash ? 'hash' : 'number']: blockHashOrBlockNumber});
   }
 
   /**

--- a/src/ain.ts
+++ b/src/ain.ts
@@ -192,7 +192,7 @@ export default class Ain {
   }
 
   /**
-   * Fetches the forger's address of a block with a block number.
+   * Fetches the block proproser's address of a block with a block number.
    * @param {number} blockNumber The block number.
    * @returns {Promise<string>}
    */
@@ -201,7 +201,7 @@ export default class Ain {
   }
 
   /**
-   * Fetches the forger's address of a block with a block hash.
+   * Fetches the block proproser's address of a block with a block hash.
    * @param {string} blockHash The block hash.
    * @returns {Promise<string>}
    */


### PR DESCRIPTION
Change summary:
- Split getProposer() to getProposerByNumber() and getProposerByHash()
- Split getValidators() to getValidatorsByNumber() and getValidatorsByHash()
- Add getValidatorInfo() method

Related issues:
- https://github.com/ainblockchain/ain-blockchain/issues/1248