### PR TITLE
Add missing network methods to ain-js

### DIFF
--- a/__tests__/__snapshots__/ain.test.ts.snap
+++ b/__tests__/__snapshots__/ain.test.ts.snap
@@ -274,5 +274,3 @@ Object {
   },
 }
 `;
-
-exports[`ain-js Network should set provider 1`] = `true`;

--- a/__tests__/ain.test.ts
+++ b/__tests__/ain.test.ts
@@ -43,10 +43,24 @@ describe('ain-js', function() {
 
     it('should set provider', async function() {
       ain.setProvider(test_node_2);
+      expect(ain.provider).not.toBeNull();
+      expect(ain.net).not.toBeNull();
+    });
+
+    it('getNetworkId', async function() {
       expect(await ain.net.getNetworkId()).toBe(0);
-      expect(await ain.net.isListening()).toMatchSnapshot();
-      expect(await ain.net.getPeerCount()).toBeGreaterThan(0);
+    });
+
+    it('isListening', async function() {
+      expect(await ain.net.isListening()).toBe(true);
+    });
+
+    it('isSyncing', async function() {
       expect(await ain.net.isSyncing()).toBe(false);
+    });
+
+    it('getPeerCount', async function() {
+      expect(await ain.net.getPeerCount()).toBeGreaterThan(0);
     });
 
     it('getProtocolVersion', async function() {

--- a/__tests__/ain.test.ts
+++ b/__tests__/ain.test.ts
@@ -51,6 +51,10 @@ describe('ain-js', function() {
       expect(await ain.net.getNetworkId()).toBe(0);
     });
 
+    it('getChainId', async function() {
+      expect(await ain.net.getChainId()).toBe(0);
+    });
+
     it('isListening', async function() {
       expect(await ain.net.isListening()).toBe(true);
     });
@@ -61,6 +65,19 @@ describe('ain-js', function() {
 
     it('getPeerCount', async function() {
       expect(await ain.net.getPeerCount()).toBeGreaterThan(0);
+    });
+
+    it('getConsensusStatus', async function() {
+      const status = await ain.net.getConsensusStatus();
+      expect(status).not.toBeNull();
+      expect(status.state).toBe('RUNNING');
+    });
+
+    it('getRawConsensusStatus', async function() {
+      const status = await ain.net.getRawConsensusStatus();
+      expect(status).not.toBeNull();
+      expect(status.consensus).not.toBeNull();
+      expect(status.consensus.state).toBe('RUNNING');
     });
 
     it('getProtocolVersion', async function() {

--- a/__tests__/ain.test.ts
+++ b/__tests__/ain.test.ts
@@ -80,6 +80,13 @@ describe('ain-js', function() {
       expect(status.consensus.state).toBe('RUNNING');
     });
 
+    it('getPeerCandidateInfo', async function() {
+      const info = await ain.net.getPeerCandidateInfo();
+      expect(info.address).not.toBeNull();
+      expect(info.isAvailableForConnection).toBe(true);
+      expect(info.peerCandidateJsonRpcUrlList).not.toBeNull();
+    });
+
     it('getProtocolVersion', async function() {
       await ain.net.getProtocolVersion()
       .then(res => {

--- a/__tests__/test_data.ts
+++ b/__tests__/test_data.ts
@@ -3,5 +3,5 @@ export const test_pw = 'ainetwork';
 export const test_seed = 'receive ocean impact unaware march just dragon easy power muscle together flip';
 
 export const test_node_1 = 'http://localhost:8081';
-export const test_node_2 = 'http://localhost:8081';
+export const test_node_2 = 'http://localhost:8082';
 export const test_event_handler_node = 'http://localhost:8083';

--- a/src/net.ts
+++ b/src/net.ts
@@ -21,6 +21,13 @@ export default class Network {
   }
 
   /**
+   * Fetches the ID of the network the blokchain node is connected to.
+   */
+  getNetworkId(): Promise<string> {
+    return this.provider.send('net_getNetworkId');
+  }
+
+  /**
    * Checks whether the blockchain node is listening for network connections.
    * @returns {Promise<boolean>}
    */
@@ -29,10 +36,19 @@ export default class Network {
   }
 
   /**
-   * Fetches the ID of the network the blokchain node is connected to.
+   * Checks whether the blockchain node is syncing with the network or not.
+   * @returns {Promise<boolean>}
    */
-  getNetworkId(): Promise<string> {
-    return this.provider.send('net_getNetworkId');
+  isSyncing(): Promise<boolean> {
+    return this.provider.send('net_syncing');
+  }
+
+  /**
+   * Fetches the number of the peers the blockchain node is connected to.
+   * @returns {Promise<number>}
+   */
+  getPeerCount(): Promise<number> {
+    return this.provider.send('net_peerCount');
   }
 
   /**
@@ -47,22 +63,6 @@ export default class Network {
    */
   getProtocolVersion(): Promise<any> {
     return this.provider.send('ain_getProtocolVersion');
-  }
-
-  /**
-   * Fetches the number of the peers the blockchain node is connected to.
-   * @returns {Promise<number>}
-   */
-  getPeerCount(): Promise<number> {
-    return this.provider.send('net_peerCount');
-  }
-
-  /**
-   * Checks whether the blockchain node is syncing with the network or not.
-   * @returns {Promise<boolean>}
-   */
-  isSyncing(): Promise<boolean> {
-    return this.provider.send('net_syncing');
   }
 
   /**

--- a/src/net.ts
+++ b/src/net.ts
@@ -75,6 +75,14 @@ export default class Network {
   }
 
   /**
+   * Fetches the peer candidate information of the blockchain node.
+   * @returns {Promise<any>}
+   */
+  getPeerCandidateInfo(): Promise<any> {
+    return this.provider.send('p2p_getPeerCandidateInfo');
+  }
+
+  /**
    * Checks the protocol version compatibility with the blockchain node.
    */
   async checkProtocolVersion(): Promise<any> {

--- a/src/net.ts
+++ b/src/net.ts
@@ -28,6 +28,13 @@ export default class Network {
   }
 
   /**
+   * Fetches the ID of the chain the blokchain node is validating.
+   */
+  getChainId(): Promise<string> {
+    return this.provider.send('net_getChainId');
+  }
+
+  /**
    * Checks whether the blockchain node is listening for network connections.
    * @returns {Promise<boolean>}
    */
@@ -49,6 +56,22 @@ export default class Network {
    */
   getPeerCount(): Promise<number> {
     return this.provider.send('net_peerCount');
+  }
+
+  /**
+   * Fetches the consensus status of the network.
+   * @returns {Promise<any>}
+   */
+  getConsensusStatus(): Promise<any> {
+    return this.provider.send('net_consensusStatus');
+  }
+
+  /**
+   * Fetches the consensus status raw data of the network.
+   * @returns {Promise<any>}
+   */
+  getRawConsensusStatus(): Promise<any> {
+    return this.provider.send('net_rawConsensusStatus');
   }
 
   /**


### PR DESCRIPTION
Change summary:
- Add getChainId() method
- Add getConsensusStatus() method 
- Add getRawConsensusStatus() metod
- Add getPeerCandidateInfo() method 
- Fix test endpoint port number 

Related issues:
- https://github.com/ainblockchain/ain-blockchain/issues/1248 