### PR TITLE
Set event handler websocket url by Ain constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ yarn add @ainblockchain/ain-js
 ## Examples
 ```
 const Ain = require('./lib/ain').default;
-const ain = new Ain('http://node.ainetwork.ai:8080/');
+const ain = new Ain('http://localhost:8081/', 'ws://localhost:5100/');
+// or const ain = new Ain('https://testnet-api.ainetwork.ai/', 'wss://testnet-event.ainetwork.ai/');
 
 ain.wallet.create(1);
 

--- a/__tests__/ain.test.ts
+++ b/__tests__/ain.test.ts
@@ -27,7 +27,7 @@ describe('ain-js', function() {
     it('chainId', function() {
       expect(ain.chainId).toBe(0);
       expect(ain.wallet.chainId).toBe(0);
-      ain.setProvider(test_node_1, 2);
+      ain.setProvider(test_node_1, null, 2);
       expect(ain.chainId).toBe(2);
       expect(ain.wallet.chainId).toBe(2);
     });
@@ -401,7 +401,7 @@ describe('ain-js', function() {
 
     it('chainId', function() {
       // chainId = 0
-      ain.setProvider(test_node_2, 0);
+      ain.setProvider(test_node_2, null, 0);
       let tx: TransactionBody = {
         nonce: 17,
         gas_price: 500,
@@ -419,7 +419,7 @@ describe('ain-js', function() {
       expect(ain.wallet.recover(sig)).toBe(addr);
 
       // chainId = 2
-      ain.setProvider(test_node_2, 2);
+      ain.setProvider(test_node_2, null, 2);
       tx = {
         nonce: 17,
         timestamp: Date.now(),
@@ -476,7 +476,7 @@ describe('ain-js', function() {
     }
 
     beforeAll(async () => {
-      ain.setProvider(test_node_2, 0);
+      ain.setProvider(test_node_2, null, 0);
       const newAccounts = ain.wallet.create(2);
       defaultAddr = ain.wallet.defaultAccount!.address as string;
       addr1 = newAccounts[0];

--- a/__tests__/ain_raw.test.ts
+++ b/__tests__/ain_raw.test.ts
@@ -15,7 +15,7 @@ const TEST_ADDR = '0x08Aed7AF9354435c38d52143EE50ac839D20696b';
 jest.setTimeout(180000);
 
 describe('ain-js', function() {
-  const ain = new Ain(test_node_1, 0, { rawResultMode: true });
+  const ain = new Ain(test_node_1, null, 0, { rawResultMode: true });
 
   beforeAll(() => {
     ain.wallet.add(TEST_SK);
@@ -61,7 +61,7 @@ describe('ain-js', function() {
     }
 
     beforeAll(async () => {
-      ain.setProvider(test_node_2, 0);
+      ain.setProvider(test_node_2, null, 0);
       const newAccounts = ain.wallet.create(2);
       defaultAddr = ain.wallet.defaultAccount!.address as string;
       addr1 = newAccounts[0];

--- a/__tests__/event_manager.test.ts
+++ b/__tests__/event_manager.test.ts
@@ -2,13 +2,15 @@
 import Ain from '../src/ain';
 import { FAILED_TO_REGISTER_ERROR_CODE } from '../src/constants';
 import { FilterDeletionReasons, TransactionStates } from '../src/types';
-
-const { test_event_handler_node } = require('./test_data');
+const {
+  test_node_3,
+  test_event_handler_node,
+} = require('./test_data');
 
 jest.setTimeout(180000);
 
 describe('Event Handler', function() {
-  let ain = new Ain(test_event_handler_node);
+  let ain = new Ain(test_node_3, test_event_handler_node);
   let eventFilterId: string;
 
   beforeAll(async () => {

--- a/__tests__/test_data.ts
+++ b/__tests__/test_data.ts
@@ -4,4 +4,5 @@ export const test_seed = 'receive ocean impact unaware march just dragon easy po
 
 export const test_node_1 = 'http://localhost:8081';
 export const test_node_2 = 'http://localhost:8082';
-export const test_event_handler_node = 'http://localhost:8083';
+export const test_node_3 = 'http://localhost:8083';
+export const test_event_handler_node = 'ws://localhost:5100';

--- a/samples/event_manager.js
+++ b/samples/event_manager.js
@@ -1,5 +1,5 @@
 const Ain = require('@ainblockchain/ain-js').default;
-const ain = new Ain('https://testnet-event.ainetwork.ai/');
+const ain = new Ain('https://testnet-api.ainetwork.ai/', 'wss://testnet-event.ainetwork.ai/');
 
 async function main() {
   await ain.em.connect(); // NOTE: https://docs.ainetwork.ai/reference/blockchain-sdk/ain-js/ain.em#connect

--- a/src/ain.ts
+++ b/src/ain.ts
@@ -23,6 +23,8 @@ export default class Ain {
   public axiosConfig: AxiosRequestConfig | undefined;
   /** The chain ID of the blockchain network. */
   public chainId: number;
+  /** The endpoint Url of the event handler websocket server. */
+  public eventHandlerUrl?: string | null;
   /** The network provider object. */
   public provider: Provider;
   /** The raw result mode option. */
@@ -43,12 +45,14 @@ export default class Ain {
   /**
    * Creates a new Ain object.
    * @param {string} providerUrl The endpoint URL of the network provider.
+   * @param {string} eventHandlerUrl The endpoint URL of the event handler websocket server.
    * @param {number} chainId The chain ID of the blockchain network.
    * @param {AinOptions} ainOptions The options of the class.
    */
-  constructor(providerUrl: string, chainId?: number, ainOptions?: AinOptions) {
+  constructor(providerUrl: string, eventHandlerUrl?: string, chainId?: number, ainOptions?: AinOptions) {
     this.axiosConfig = ainOptions?.axiosConfig;
     this.provider = new Provider(this, providerUrl, this.axiosConfig);
+    this.eventHandlerUrl = eventHandlerUrl;
     this.chainId = chainId || 0;
     this.rawResultMode = ainOptions?.rawResultMode || false;
     this.net = new Network(this.provider);
@@ -61,15 +65,17 @@ export default class Ain {
 
   /**
    * Sets a new provider.
-   * @param {string} providerUrl The endpoint URL of the network provider.
-   * @param {number} chainId The chain ID of the blockchain network.
+   * @param {string} providerUrl The endpoint URL of the network provider. e.g. https://testnet-api.ainetwork.ai, http://localhost:8081
+   * @param {string} eventHandlerUrl The endpoint URL of the event handler websocket server. e.g. wss://testnet-event.ainetwork.ai, ws://localhost:5100
+   * @param {number} chainId The chain ID of the blockchain network. e.g. 0 for local or testnet, and 1 for mainnet
    * @param {AxiosRequestConfig} axiosConfig The axios request config.
    */
-  setProvider(providerUrl: string, chainId?: number, axiosConfig?: AxiosRequestConfig | undefined) {
+  setProvider(providerUrl: string, eventHandlerUrl?: string, chainId?: number, axiosConfig?: AxiosRequestConfig | undefined) {
     if (axiosConfig) {
       this.axiosConfig = axiosConfig;
     }
     this.provider = new Provider(this, providerUrl, this.axiosConfig);
+    this.eventHandlerUrl = eventHandlerUrl;
     this.chainId = chainId || 0;
     this.db = new Database(this, this.provider);
     this.net = new Network(this.provider);

--- a/src/ain.ts
+++ b/src/ain.ts
@@ -65,8 +65,8 @@ export default class Ain {
 
   /**
    * Sets a new provider.
-   * @param {string} providerUrl The endpoint URL of the network provider. e.g. https://testnet-api.ainetwork.ai, http://localhost:8081
-   * @param {string} eventHandlerUrl The endpoint URL of the event handler websocket server. e.g. wss://testnet-event.ainetwork.ai, ws://localhost:5100
+   * @param {string} providerUrl The endpoint URL of the network provider. e.g. http://localhost:8081, https://testnet-api.ainetwork.ai
+   * @param {string} eventHandlerUrl The endpoint URL of the event handler websocket server. e.g.  ws://localhost:5100, wss://testnet-event.ainetwork.ai
    * @param {number} chainId The chain ID of the blockchain network. e.g. 0 for local or testnet, and 1 for mainnet
    * @param {AxiosRequestConfig} axiosConfig The axios request config.
    */

--- a/src/event-manager/event-channel-client.ts
+++ b/src/event-manager/event-channel-client.ts
@@ -24,8 +24,6 @@ export default class EventChannelClient {
   private readonly _eventCallbackManager: EventCallbackManager;
   /** The web socket client. */
   private _ws?: WebSocket | WebSocketBE;
-  /** The blockchain endpoint URL. */
-  private _endpointUrl?: string;
   /** Whether it's connected or not. */
   private _isConnected: boolean;
   /** The handshake timeout object. */
@@ -42,7 +40,6 @@ export default class EventChannelClient {
     this._ain = ain;
     this._eventCallbackManager = eventCallbackManager;
     this._ws = undefined;
-    this._endpointUrl = undefined;
     this._isConnected = false;
     this._handshakeTimeout = undefined;
     this._heartbeatTimeout = undefined;
@@ -63,6 +60,13 @@ export default class EventChannelClient {
         reject(new Error(`Can't connect multiple channels`));
         return;
       }
+      const url = this._ain.eventHandlerUrl;
+      if (!url) {
+        reject(new Error(`eventHandlerUrl is not set properly: ${url}`));
+        return;
+      }
+      // TODO(platfowner): Remove or re-implement without using getEventHandlerNetworkInfo() below.
+      /*
       const eventHandlerNetworkInfo = await this._ain.net.getEventHandlerNetworkInfo();
       const url = eventHandlerNetworkInfo.url;
       if (!url) {
@@ -86,8 +90,8 @@ export default class EventChannelClient {
         reject(new Error(`Exceed event channel limit! (node:${url})`));
         return;
       }
+      */
 
-      this._endpointUrl = url;
       // NOTE(platfowner): Fix WebSocket module import issue (see https://github.com/ainblockchain/ain-js/issues/177).
       this._ws = isBrowser ? new WebSocket(url) : new WebSocketBE(url);
       // NOTE(platfowner): A custom handshake timeout (see https://github.com/ainblockchain/ain-js/issues/171).

--- a/src/he/README.md
+++ b/src/he/README.md
@@ -29,7 +29,8 @@ This is a function developed for testing purposes. It returns the secret key cur
 
 ## Usage
 ```ts
-const ain = new Ain('http://node.ainetwork.ai:8080');
+const ain = new Ain('http://localhost:8081', 'ws://localhost:5100');
+// or const ain = new Ain('https://testnet-api.ainetwork.ai/', 'wss://testnet-event.ainetwork.ai/');
 await ain.he.init();
 const TEST_DATA = Float64Array.from({ length: ain.he.seal.encoder.slotCount }).map((x, i) => i);
 const cipherText = ain.he.encrypt(TEST_DATA);


### PR DESCRIPTION
Change summary:
- Set event handler websocket url by Ain constructor (not from getEventHandlerNetworkInfo())

Background:
- This is needed for using secure websocket load balancer

Related issues:
- https://github.com/ainblockchain/ain-blockchain/issues/1272