### PR TITLE
Allow null for eventHandlerUrl param

### DIFF
--- a/src/ain.ts
+++ b/src/ain.ts
@@ -45,11 +45,11 @@ export default class Ain {
   /**
    * Creates a new Ain object.
    * @param {string} providerUrl The endpoint URL of the network provider.
-   * @param {string} eventHandlerUrl The endpoint URL of the event handler websocket server.
+   * @param {string | null} eventHandlerUrl The endpoint URL of the event handler websocket server.
    * @param {number} chainId The chain ID of the blockchain network.
    * @param {AinOptions} ainOptions The options of the class.
    */
-  constructor(providerUrl: string, eventHandlerUrl?: string, chainId?: number, ainOptions?: AinOptions) {
+  constructor(providerUrl: string, eventHandlerUrl?: string | null, chainId?: number, ainOptions?: AinOptions) {
     this.axiosConfig = ainOptions?.axiosConfig;
     this.provider = new Provider(this, providerUrl, this.axiosConfig);
     this.eventHandlerUrl = eventHandlerUrl;
@@ -66,11 +66,11 @@ export default class Ain {
   /**
    * Sets a new provider.
    * @param {string} providerUrl The endpoint URL of the network provider. e.g. http://localhost:8081, https://testnet-api.ainetwork.ai
-   * @param {string} eventHandlerUrl The endpoint URL of the event handler websocket server. e.g.  ws://localhost:5100, wss://testnet-event.ainetwork.ai
+   * @param {string | null} eventHandlerUrl The endpoint URL of the event handler websocket server. e.g.  ws://localhost:5100, wss://testnet-event.ainetwork.ai
    * @param {number} chainId The chain ID of the blockchain network. e.g. 0 for local or testnet, and 1 for mainnet
    * @param {AxiosRequestConfig} axiosConfig The axios request config.
    */
-  setProvider(providerUrl: string, eventHandlerUrl?: string, chainId?: number, axiosConfig?: AxiosRequestConfig | undefined) {
+  setProvider(providerUrl: string, eventHandlerUrl?: string | null, chainId?: number, axiosConfig?: AxiosRequestConfig | undefined) {
     if (axiosConfig) {
       this.axiosConfig = axiosConfig;
     }


### PR DESCRIPTION
Change summary:
- Allow null for eventHandlerUrl param

Related issues:
- https://github.com/ainblockchain/ain-blockchain/issues/1273